### PR TITLE
feat: 통합 확인 — 헬스체크 표시 및 README 작성

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,70 @@
-# DoLinear
+# DOLinear
 
-Linear clone project.
+A Linear clone for project management, built with a modern TypeScript stack.
+
+## Tech Stack
+
+- **Frontend**: React + Vite + TypeScript + TanStack Router + TanStack Query + Tailwind CSS v4
+- **Backend**: Hono + TypeScript + Node.js
+- **Database**: PostgreSQL 15 + Drizzle ORM
+- **Auth**: Better Auth (Email/Password)
+- **Testing**: Vitest + Testcontainers
+- **Infra**: Docker Compose, pnpm + Turborepo monorepo
+
+## Project Structure
+
+```
+dolinear/
+├── apps/
+│   ├── web/        # React frontend (port 5173)
+│   └── api/        # Hono API server (port 3001)
+├── packages/
+│   └── shared/     # Shared types and utilities
+├── docker-compose.yml
+├── turbo.json
+└── pnpm-workspace.yaml
+```
+
+## Local Development Setup
+
+### Prerequisites
+
+- Node.js 20+
+- pnpm 10+
+- Docker & Docker Compose
+
+### Getting Started
+
+1. **Start the database**:
+   ```bash
+   docker compose up -d
+   ```
+
+2. **Install dependencies**:
+   ```bash
+   pnpm install
+   ```
+
+3. **Push database schema**:
+   ```bash
+   pnpm --filter api db:push
+   ```
+
+4. **Start development servers**:
+   ```bash
+   pnpm dev
+   ```
+
+   This starts both the frontend (http://localhost:5173) and API (http://localhost:3001) concurrently via Turborepo.
+
+## Available Scripts
+
+| Command | Description |
+|---|---|
+| `pnpm dev` | Start all apps in development mode |
+| `pnpm build` | Build all packages and apps |
+| `pnpm db:up` | Start PostgreSQL via Docker Compose |
+| `pnpm db:down` | Stop PostgreSQL |
+| `pnpm --filter api db:push` | Push Drizzle schema to database |
+| `pnpm --filter api db:generate` | Generate Drizzle migrations |
+| `pnpm --filter api db:studio` | Open Drizzle Studio |

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,15 +1,68 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
 
 export const Route = createFileRoute('/')({
   component: IndexPage,
 })
 
+interface HealthResponse {
+  status: string
+  db: string
+}
+
 function IndexPage() {
+  const { data, isLoading, isError } = useQuery<HealthResponse>({
+    queryKey: ['health'],
+    queryFn: async () => {
+      const res = await fetch('http://localhost:3001/health')
+      if (!res.ok) {
+        const body = await res.json()
+        return body as HealthResponse
+      }
+      return res.json()
+    },
+    refetchInterval: 10000,
+  })
+
   return (
     <div className="flex items-center justify-center min-h-screen">
       <div className="text-center">
         <h1 className="text-4xl font-bold text-white mb-4">DOLinear</h1>
-        <p className="text-lg text-gray-400">Project management, reimagined.</p>
+        <p className="text-lg text-gray-400 mb-8">
+          Project management, reimagined.
+        </p>
+        <div className="rounded-lg bg-white/5 border border-white/10 p-6 inline-block text-left">
+          <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-3">
+            System Status
+          </h2>
+          {isLoading && (
+            <p className="text-gray-400">Checking API status...</p>
+          )}
+          {isError && (
+            <p className="text-red-400">API unreachable</p>
+          )}
+          {data && (
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <span
+                  className={`w-2 h-2 rounded-full ${data.status === 'ok' ? 'bg-green-400' : 'bg-red-400'}`}
+                />
+                <span className="text-gray-300">
+                  API: {data.status === 'ok' ? 'Healthy' : 'Unhealthy'}
+                </span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span
+                  className={`w-2 h-2 rounded-full ${data.db === 'connected' ? 'bg-green-400' : 'bg-red-400'}`}
+                />
+                <span className="text-gray-300">
+                  Database:{' '}
+                  {data.db === 'connected' ? 'Connected' : 'Disconnected'}
+                </span>
+              </div>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Home page now fetches `/health` API and displays API + database connection status using TanStack Query
- Added comprehensive README with tech stack, project structure, local development setup guide, and available scripts

Closes #6

## Test plan
- [x] `pnpm install` completes successfully
- [x] `pnpm build` completes without errors
- [x] `docker compose up -d` starts PostgreSQL
- [x] `pnpm dev` starts both web (5173) and api (3001) concurrently
- [x] `curl http://localhost:3001/health` returns `{"status":"ok","db":"connected"}`
- [x] `curl http://localhost:5173` serves the frontend HTML
- [x] Health check status is displayed on the home page (API: Healthy, Database: Connected)
- [x] README contains project intro, tech stack, setup guide, and scripts table

🤖 Generated with [Claude Code](https://claude.com/claude-code)