### PR TITLE
feat: 인증 미들웨어 + 보호된 라우트

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,9 +3,11 @@ import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 import { serve } from '@hono/node-server'
 import { auth } from './auth.js'
+import { authMiddleware } from './middleware/auth.js'
 import { healthRoute } from './routes/index.js'
+import type { Env } from './types.js'
 
-const app = new Hono()
+const app = new Hono<Env>()
 
 app.use(
   '*',
@@ -14,6 +16,8 @@ app.use(
     credentials: true,
   }),
 )
+
+app.use('*', authMiddleware)
 
 app.on(['POST', 'GET'], '/api/auth/**', (c) => auth.handler(c.req.raw))
 

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,0 +1,33 @@
+import { createMiddleware } from 'hono/factory'
+import { auth } from '../auth.js'
+import type { Env } from '../types.js'
+
+const PUBLIC_PATHS = ['/health']
+
+export const authMiddleware = createMiddleware<Env>(async (c, next) => {
+  const path = c.req.path
+
+  if (PUBLIC_PATHS.includes(path) || path.startsWith('/api/auth/')) {
+    return next()
+  }
+
+  const session = await auth.api.getSession({
+    headers: c.req.raw.headers,
+  })
+
+  if (!session) {
+    return c.json(
+      {
+        error: 'UnauthorizedError',
+        message: 'Unauthorized',
+        statusCode: 401,
+      },
+      401,
+    )
+  }
+
+  c.set('user', session.user)
+  c.set('session', session.session)
+
+  return next()
+})

--- a/apps/api/src/test/auth-helpers.ts
+++ b/apps/api/src/test/auth-helpers.ts
@@ -1,0 +1,22 @@
+import type { Hono } from 'hono'
+import type { Env } from '../types.js'
+
+export async function createAuthenticatedUser(
+  app: Hono<Env>,
+  options?: { email?: string; name?: string; password?: string },
+) {
+  const email = options?.email ?? 'test@example.com'
+  const name = options?.name ?? 'Test User'
+  const password = options?.password ?? 'password123'
+
+  const signUpRes = await app.request('/api/auth/sign-up/email', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, name, password }),
+  })
+
+  const cookies = signUpRes.headers.getSetCookie()
+  const cookieHeader = cookies.map((c) => c.split(';')[0]).join('; ')
+
+  return { cookieHeader, email, name }
+}

--- a/apps/api/src/test/middleware/auth.test.ts
+++ b/apps/api/src/test/middleware/auth.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { Hono } from 'hono'
+import { sql } from 'drizzle-orm'
+import { auth } from '../../auth.js'
+import { authMiddleware } from '../../middleware/auth.js'
+import { createAuthenticatedUser } from '../auth-helpers.js'
+import { createTestDb } from '../helpers.js'
+import type { Env } from '../../types.js'
+
+describe('Auth Middleware', () => {
+  const { db, client } = createTestDb()
+
+  function createApp() {
+    const app = new Hono<Env>()
+
+    app.on(['POST', 'GET'], '/api/auth/**', (c) => auth.handler(c.req.raw))
+    app.use('*', authMiddleware)
+
+    app.get('/health', (c) => c.json({ status: 'ok' }))
+
+    app.get('/protected', (c) => {
+      const user = c.get('user')
+      return c.json({ user: { id: user.id, email: user.email } })
+    })
+
+    return app
+  }
+
+  beforeEach(async () => {
+    await db.execute(sql`TRUNCATE TABLE "session" CASCADE`)
+    await db.execute(sql`TRUNCATE TABLE "account" CASCADE`)
+    await db.execute(sql`TRUNCATE TABLE "user" CASCADE`)
+    await db.execute(sql`TRUNCATE TABLE "verification" CASCADE`)
+  })
+
+  afterAll(async () => {
+    await client.end()
+  })
+
+  it('should allow access with valid session', async () => {
+    const app = createApp()
+    const { cookieHeader } = await createAuthenticatedUser(app)
+
+    const res = await app.request('/protected', {
+      headers: { Cookie: cookieHeader },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.user).toBeDefined()
+    expect(body.user.email).toBe('test@example.com')
+  })
+
+  it('should return 401 for invalid session', async () => {
+    const app = createApp()
+
+    const res = await app.request('/protected', {
+      headers: { Cookie: 'better-auth.session_token=invalid-token' },
+    })
+
+    expect(res.status).toBe(401)
+    const body = await res.json()
+    expect(body.error).toBe('UnauthorizedError')
+    expect(body.message).toBe('Unauthorized')
+  })
+
+  it('should return 401 when no session is provided', async () => {
+    const app = createApp()
+
+    const res = await app.request('/protected')
+
+    expect(res.status).toBe(401)
+    const body = await res.json()
+    expect(body.error).toBe('UnauthorizedError')
+  })
+
+  it('should bypass middleware for /health and /api/auth/**', async () => {
+    const app = createApp()
+
+    const healthRes = await app.request('/health')
+    expect(healthRes.status).toBe(200)
+    const healthBody = await healthRes.json()
+    expect(healthBody.status).toBe('ok')
+
+    const authRes = await app.request('/api/auth/sign-in/email', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'nonexistent@example.com',
+        password: 'password123',
+      }),
+    })
+    // Better Auth handles this request, not our middleware.
+    // It may return 401 for invalid credentials, but the response body
+    // should NOT contain our middleware's error format.
+    if (authRes.status === 401) {
+      const body = await authRes.json()
+      expect(body.error).not.toBe('UnauthorizedError')
+    }
+  })
+})

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -1,0 +1,10 @@
+import type { auth } from './auth.js'
+
+type Session = typeof auth.$Infer.Session
+
+export type Env = {
+  Variables: {
+    user: Session['user']
+    session: Session['session']
+  }
+}


### PR DESCRIPTION
## Summary
- Better Auth 세션 기반 인증 미들웨어 구현
- /api/auth/**, /health 경로 제외
- 401 응답 처리
- 테스트 헬퍼 + 통합 테스트 4개 케이스

Closes #27

## Test plan
- [ ] 유효한 세션으로 보호된 라우트 접근 → 200
- [ ] 세션 없이 보호된 라우트 접근 → 401
- [ ] /health 접근 → 미들웨어 미적용
- [ ] /api/auth/** 접근 → 미들웨어 미적용
- [ ] pnpm --filter api test 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)