### PR TITLE
feat: API 클라이언트 + React Query 훅

### DIFF
--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -1,0 +1,15 @@
+export {
+  useWorkspaces,
+  useWorkspace,
+  useCreateWorkspace,
+} from './use-workspaces'
+export { useTeams, useTeam, useCreateTeam } from './use-teams'
+export {
+  useIssues,
+  useIssue,
+  useCreateIssue,
+  useUpdateIssue,
+} from './use-issues'
+export { useLabels, useCreateLabel } from './use-labels'
+export { useComments, useCreateComment } from './use-comments'
+export { useWorkflowStates } from './use-workflow-states'

--- a/apps/web/src/hooks/use-comments.ts
+++ b/apps/web/src/hooks/use-comments.ts
@@ -1,0 +1,33 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import type { ApiResponse, Comment } from '@dolinear/shared'
+import { apiClient } from '@/lib/api-client'
+import { queryKeys } from '@/lib/query-keys'
+
+export function useComments(issueId: string) {
+  return useQuery({
+    queryKey: queryKeys.comments.list(issueId),
+    queryFn: () =>
+      apiClient
+        .get<ApiResponse<Comment[]>>(`/issues/${issueId}/comments`)
+        .then((r) => r.data),
+    enabled: !!issueId,
+  })
+}
+
+export function useCreateComment() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: { body: string; issueId: string }) =>
+      apiClient
+        .post<ApiResponse<Comment>>(`/issues/${data.issueId}/comments`, {
+          body: data.body,
+        })
+        .then((r) => r.data),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.comments.list(variables.issueId),
+      })
+    },
+  })
+}

--- a/apps/web/src/hooks/use-issues.ts
+++ b/apps/web/src/hooks/use-issues.ts
@@ -1,0 +1,68 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import type { ApiResponse, Issue, IssuePriority } from '@dolinear/shared'
+import { apiClient } from '@/lib/api-client'
+import { queryKeys } from '@/lib/query-keys'
+
+export function useIssues(teamId: string) {
+  return useQuery({
+    queryKey: queryKeys.issues.list({ teamId }),
+    queryFn: () =>
+      apiClient
+        .get<ApiResponse<Issue[]>>(`/teams/${teamId}/issues`)
+        .then((r) => r.data),
+    enabled: !!teamId,
+  })
+}
+
+export function useIssue(id: string) {
+  return useQuery({
+    queryKey: queryKeys.issues.detail(id),
+    queryFn: () =>
+      apiClient.get<ApiResponse<Issue>>(`/issues/${id}`).then((r) => r.data),
+    enabled: !!id,
+  })
+}
+
+export function useCreateIssue() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: {
+      title: string
+      description?: string
+      teamId: string
+      priority?: IssuePriority
+      assigneeId?: string
+      parentId?: string
+    }) =>
+      apiClient.post<ApiResponse<Issue>>('/issues', data).then((r) => r.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.all })
+    },
+  })
+}
+
+export function useUpdateIssue() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({
+      id,
+      ...data
+    }: {
+      id: string
+      title?: string
+      description?: string | null
+      status?: string
+      priority?: IssuePriority
+      assigneeId?: string | null
+      parentId?: string | null
+    }) =>
+      apiClient
+        .patch<ApiResponse<Issue>>(`/issues/${id}`, data)
+        .then((r) => r.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.all })
+    },
+  })
+}

--- a/apps/web/src/hooks/use-labels.ts
+++ b/apps/web/src/hooks/use-labels.ts
@@ -1,0 +1,27 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import type { ApiResponse, Label } from '@dolinear/shared'
+import { apiClient } from '@/lib/api-client'
+import { queryKeys } from '@/lib/query-keys'
+
+export function useLabels(workspaceId: string) {
+  return useQuery({
+    queryKey: queryKeys.labels.list(workspaceId),
+    queryFn: () =>
+      apiClient
+        .get<ApiResponse<Label[]>>(`/workspaces/${workspaceId}/labels`)
+        .then((r) => r.data),
+    enabled: !!workspaceId,
+  })
+}
+
+export function useCreateLabel() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: { name: string; color: string; teamId: string }) =>
+      apiClient.post<ApiResponse<Label>>('/labels', data).then((r) => r.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.labels.all })
+    },
+  })
+}

--- a/apps/web/src/hooks/use-teams.ts
+++ b/apps/web/src/hooks/use-teams.ts
@@ -1,0 +1,39 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import type { ApiResponse, Team } from '@dolinear/shared'
+import { apiClient } from '@/lib/api-client'
+import { queryKeys } from '@/lib/query-keys'
+
+export function useTeams(workspaceId: string) {
+  return useQuery({
+    queryKey: queryKeys.teams.list(workspaceId),
+    queryFn: () =>
+      apiClient
+        .get<ApiResponse<Team[]>>(`/workspaces/${workspaceId}/teams`)
+        .then((r) => r.data),
+    enabled: !!workspaceId,
+  })
+}
+
+export function useTeam(id: string) {
+  return useQuery({
+    queryKey: queryKeys.teams.detail(id),
+    queryFn: () =>
+      apiClient.get<ApiResponse<Team>>(`/teams/${id}`).then((r) => r.data),
+    enabled: !!id,
+  })
+}
+
+export function useCreateTeam() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: {
+      name: string
+      identifier: string
+      workspaceId: string
+    }) => apiClient.post<ApiResponse<Team>>('/teams', data).then((r) => r.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.teams.all })
+    },
+  })
+}

--- a/apps/web/src/hooks/use-workflow-states.ts
+++ b/apps/web/src/hooks/use-workflow-states.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query'
+import type { ApiResponse, WorkflowState } from '@dolinear/shared'
+import { apiClient } from '@/lib/api-client'
+import { queryKeys } from '@/lib/query-keys'
+
+export function useWorkflowStates(teamId: string) {
+  return useQuery({
+    queryKey: queryKeys.workflowStates.list(teamId),
+    queryFn: () =>
+      apiClient
+        .get<ApiResponse<WorkflowState[]>>(`/teams/${teamId}/workflow-states`)
+        .then((r) => r.data),
+    enabled: !!teamId,
+  })
+}

--- a/apps/web/src/hooks/use-workspaces.test.tsx
+++ b/apps/web/src/hooks/use-workspaces.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { useWorkspaces, useCreateWorkspace } from './use-workspaces'
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+describe('useWorkspaces', () => {
+  it('fetches workspaces list', async () => {
+    const workspaces = [{ id: '1', name: 'My Workspace', slug: 'my-workspace' }]
+    fetchMock.mockResolvedValue(jsonResponse({ data: workspaces }))
+
+    const { result } = renderHook(() => useWorkspaces(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data).toEqual(workspaces)
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/workspaces',
+      expect.objectContaining({ method: 'GET', credentials: 'include' }),
+    )
+  })
+
+  it('returns error on fetch failure', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    Object.defineProperty(window, 'location', {
+      value: { href: '' },
+      writable: true,
+      configurable: true,
+    })
+
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        { error: 'Forbidden', message: 'Access denied', statusCode: 403 },
+        403,
+      ),
+    )
+
+    const { result } = renderHook(() => useWorkspaces(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toBeDefined()
+  })
+})
+
+describe('useCreateWorkspace', () => {
+  it('creates workspace and invalidates queries', async () => {
+    const newWorkspace = { id: '2', name: 'New WS', slug: 'new-ws' }
+    fetchMock.mockResolvedValue(jsonResponse({ data: newWorkspace }))
+
+    const { result } = renderHook(() => useCreateWorkspace(), {
+      wrapper: createWrapper(),
+    })
+
+    result.current.mutate({ name: 'New WS', slug: 'new-ws' })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual(newWorkspace)
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/workspaces',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ name: 'New WS', slug: 'new-ws' }),
+      }),
+    )
+  })
+})

--- a/apps/web/src/hooks/use-workspaces.ts
+++ b/apps/web/src/hooks/use-workspaces.ts
@@ -1,0 +1,39 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import type { ApiResponse, Workspace } from '@dolinear/shared'
+import { apiClient } from '@/lib/api-client'
+import { queryKeys } from '@/lib/query-keys'
+
+export function useWorkspaces() {
+  return useQuery({
+    queryKey: queryKeys.workspaces.all,
+    queryFn: () =>
+      apiClient
+        .get<ApiResponse<Workspace[]>>('/workspaces')
+        .then((r) => r.data),
+  })
+}
+
+export function useWorkspace(id: string) {
+  return useQuery({
+    queryKey: queryKeys.workspaces.detail(id),
+    queryFn: () =>
+      apiClient
+        .get<ApiResponse<Workspace>>(`/workspaces/${id}`)
+        .then((r) => r.data),
+    enabled: !!id,
+  })
+}
+
+export function useCreateWorkspace() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: { name: string; slug: string }) =>
+      apiClient
+        .post<ApiResponse<Workspace>>('/workspaces', data)
+        .then((r) => r.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.workspaces.all })
+    },
+  })
+}

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { apiClient, ApiClientError } from './api-client'
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('apiClient', () => {
+  describe('GET requests', () => {
+    it('sends GET request with credentials include', async () => {
+      fetchMock.mockResolvedValue(jsonResponse({ data: [] }))
+
+      await apiClient.get('/workspaces')
+
+      expect(fetchMock).toHaveBeenCalledWith('/api/workspaces', {
+        method: 'GET',
+        headers: {},
+        credentials: 'include',
+        body: undefined,
+      })
+    })
+
+    it('returns parsed JSON response', async () => {
+      const payload = { data: [{ id: '1', name: 'ws' }] }
+      fetchMock.mockResolvedValue(jsonResponse(payload))
+
+      const result = await apiClient.get('/workspaces')
+
+      expect(result).toEqual(payload)
+    })
+  })
+
+  describe('POST requests', () => {
+    it('sends POST request with JSON body', async () => {
+      fetchMock.mockResolvedValue(jsonResponse({ data: { id: '1' } }))
+
+      await apiClient.post('/workspaces', { name: 'test' })
+
+      expect(fetchMock).toHaveBeenCalledWith('/api/workspaces', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ name: 'test' }),
+      })
+    })
+  })
+
+  describe('error handling', () => {
+    it('redirects to /login on 401', async () => {
+      const hrefSetter = vi.fn()
+      Object.defineProperty(window, 'location', {
+        value: { href: '' },
+        writable: true,
+        configurable: true,
+      })
+      Object.defineProperty(window.location, 'href', {
+        set: hrefSetter,
+        get: () => '',
+        configurable: true,
+      })
+
+      fetchMock.mockResolvedValue(jsonResponse({ error: 'Unauthorized' }, 401))
+
+      await expect(apiClient.get('/protected')).rejects.toThrow(ApiClientError)
+      expect(hrefSetter).toHaveBeenCalledWith('/login')
+    })
+
+    it('throws ApiClientError with server error details', async () => {
+      const errorBody = {
+        error: 'Validation',
+        message: 'Invalid input',
+        statusCode: 400,
+        details: { name: ['required'] },
+      }
+      fetchMock.mockResolvedValue(jsonResponse(errorBody, 400))
+
+      try {
+        await apiClient.post('/workspaces', {})
+        expect.fail('should have thrown')
+      } catch (err) {
+        expect(err).toBeInstanceOf(ApiClientError)
+        const apiErr = err as ApiClientError
+        expect(apiErr.message).toBe('Invalid input')
+        expect(apiErr.statusCode).toBe(400)
+        expect(apiErr.details).toEqual({ name: ['required'] })
+      }
+    })
+
+    it('handles non-JSON error responses', async () => {
+      fetchMock.mockResolvedValue(
+        new Response('Internal Server Error', {
+          status: 500,
+          statusText: 'Internal Server Error',
+        }),
+      )
+
+      try {
+        await apiClient.get('/broken')
+        expect.fail('should have thrown')
+      } catch (err) {
+        expect(err).toBeInstanceOf(ApiClientError)
+        const apiErr = err as ApiClientError
+        expect(apiErr.statusCode).toBe(500)
+        expect(apiErr.message).toBe('Internal Server Error')
+      }
+    })
+  })
+
+  describe('other methods', () => {
+    it('PUT sends correct method', async () => {
+      fetchMock.mockResolvedValue(jsonResponse({ data: {} }))
+
+      await apiClient.put('/issues/1', { title: 'updated' })
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/issues/1',
+        expect.objectContaining({ method: 'PUT' }),
+      )
+    })
+
+    it('PATCH sends correct method', async () => {
+      fetchMock.mockResolvedValue(jsonResponse({ data: {} }))
+
+      await apiClient.patch('/issues/1', { status: 'done' })
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/issues/1',
+        expect.objectContaining({ method: 'PATCH' }),
+      )
+    })
+
+    it('DELETE sends correct method', async () => {
+      fetchMock.mockResolvedValue(jsonResponse({ data: {} }))
+
+      await apiClient.del('/issues/1')
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/issues/1',
+        expect.objectContaining({ method: 'DELETE' }),
+      )
+    })
+  })
+})

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1,0 +1,70 @@
+import type { ApiError } from '@dolinear/shared'
+
+const BASE_URL = '/api'
+
+class ApiClientError extends Error {
+  statusCode: number
+  details?: Record<string, string[]>
+
+  constructor(error: ApiError) {
+    super(error.message)
+    this.name = 'ApiClientError'
+    this.statusCode = error.statusCode
+    this.details = error.details
+  }
+}
+
+async function request<T>(
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const url = `${BASE_URL}${path}`
+  const headers: Record<string, string> = {}
+
+  if (body !== undefined) {
+    headers['Content-Type'] = 'application/json'
+  }
+
+  const res = await fetch(url, {
+    method,
+    headers,
+    credentials: 'include',
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+
+  if (!res.ok) {
+    if (res.status === 401) {
+      window.location.href = '/login'
+      throw new ApiClientError({
+        error: 'Unauthorized',
+        message: 'Authentication required',
+        statusCode: 401,
+      })
+    }
+
+    let apiError: ApiError
+    try {
+      apiError = await res.json()
+    } catch {
+      apiError = {
+        error: 'Unknown',
+        message: res.statusText || 'An error occurred',
+        statusCode: res.status,
+      }
+    }
+    throw new ApiClientError(apiError)
+  }
+
+  return res.json() as Promise<T>
+}
+
+export const apiClient = {
+  get: <T>(path: string) => request<T>('GET', path),
+  post: <T>(path: string, body?: unknown) => request<T>('POST', path, body),
+  put: <T>(path: string, body?: unknown) => request<T>('PUT', path, body),
+  patch: <T>(path: string, body?: unknown) => request<T>('PATCH', path, body),
+  del: <T>(path: string) => request<T>('DELETE', path),
+}
+
+export { ApiClientError }

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -1,0 +1,31 @@
+export const queryKeys = {
+  workspaces: {
+    all: ['workspaces'] as const,
+    detail: (id: string) => ['workspaces', id] as const,
+    list: (filters?: Record<string, unknown>) =>
+      ['workspaces', 'list', filters] as const,
+  },
+  teams: {
+    all: ['teams'] as const,
+    detail: (id: string) => ['teams', id] as const,
+    list: (workspaceId: string) => ['teams', 'list', workspaceId] as const,
+  },
+  issues: {
+    all: ['issues'] as const,
+    detail: (id: string) => ['issues', id] as const,
+    list: (filters?: Record<string, unknown>) =>
+      ['issues', 'list', filters] as const,
+  },
+  labels: {
+    all: ['labels'] as const,
+    list: (workspaceId: string) => ['labels', 'list', workspaceId] as const,
+  },
+  comments: {
+    all: ['comments'] as const,
+    list: (issueId: string) => ['comments', 'list', issueId] as const,
+  },
+  workflowStates: {
+    all: ['workflowStates'] as const,
+    list: (teamId: string) => ['workflowStates', 'list', teamId] as const,
+  },
+}


### PR DESCRIPTION
## Summary
- fetch 기반 API 클라이언트 (credentials include, 401 핸들링)
- Query key factory 패턴
- 모든 도메인 React Query 훅 (workspaces, teams, issues, labels, comments, workflowStates)
- Mutation 후 자동 query invalidation

Closes #32

## Test plan
- [ ] api-client 401 → 로그인 리다이렉트
- [ ] api-client 에러 핸들링
- [ ] useWorkspaces 훅 쿼리 동작
- [ ] useCreateWorkspace 뮤테이션 + invalidation
- [ ] pnpm build 성공
- [ ] pnpm --filter web test 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)