### PR TITLE
feat: 백엔드 테스트 인프라 보강

### DIFF
--- a/apps/api/src/test/db.test.ts
+++ b/apps/api/src/test/db.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterAll } from 'vitest'
 import { eq, sql } from 'drizzle-orm'
-import { createTestDb } from './helpers.js'
+import { createTestDb, cleanupDatabase } from './helpers.js'
 import { user } from '../db/schema/index.js'
 import { randomUUID } from 'node:crypto'
 
@@ -8,7 +8,7 @@ describe('Database', () => {
   const { db, client } = createTestDb()
 
   beforeEach(async () => {
-    await db.execute(sql`TRUNCATE TABLE "user" CASCADE`)
+    await cleanupDatabase(db)
   })
 
   afterAll(async () => {

--- a/apps/api/src/test/fixtures.ts
+++ b/apps/api/src/test/fixtures.ts
@@ -1,0 +1,57 @@
+import { randomUUID } from 'node:crypto'
+import type { User, Workspace, Team, Issue } from '@dolinear/shared'
+
+export function buildUser(overrides?: Partial<User>): User {
+  return {
+    id: randomUUID(),
+    name: 'Test User',
+    email: `user-${randomUUID().slice(0, 8)}@example.com`,
+    emailVerified: false,
+    image: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}
+
+export function buildWorkspace(overrides?: Partial<Workspace>): Workspace {
+  return {
+    id: randomUUID(),
+    name: 'Test Workspace',
+    slug: `workspace-${randomUUID().slice(0, 8)}`,
+    ownerId: randomUUID(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}
+
+export function buildTeam(overrides?: Partial<Team>): Team {
+  return {
+    id: randomUUID(),
+    name: 'Test Team',
+    identifier: `TM-${randomUUID().slice(0, 4).toUpperCase()}`,
+    workspaceId: randomUUID(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}
+
+export function buildIssue(overrides?: Partial<Issue>): Issue {
+  return {
+    id: randomUUID(),
+    title: 'Test Issue',
+    description: null,
+    status: 'todo',
+    priority: 'none',
+    number: 1,
+    teamId: randomUUID(),
+    assigneeId: null,
+    creatorId: randomUUID(),
+    parentId: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}

--- a/apps/api/src/test/helpers.ts
+++ b/apps/api/src/test/helpers.ts
@@ -1,6 +1,12 @@
 import { drizzle } from 'drizzle-orm/postgres-js'
+import { sql } from 'drizzle-orm'
 import postgres from 'postgres'
+import { Hono } from 'hono'
+import { cors } from 'hono/cors'
+import { betterAuth } from 'better-auth'
+import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import * as schema from '../db/schema/index.js'
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js'
 
 export function createTestDb() {
   const connectionString = process.env.DATABASE_URL!
@@ -8,4 +14,92 @@ export function createTestDb() {
   const db = drizzle(client, { schema })
 
   return { db, client }
+}
+
+export function createTestApp(db: PostgresJsDatabase<typeof schema>) {
+  const auth = betterAuth({
+    database: drizzleAdapter(db, {
+      provider: 'pg',
+      schema,
+    }),
+    emailAndPassword: {
+      enabled: true,
+    },
+    trustedOrigins: ['http://localhost:5173'],
+  })
+
+  const app = new Hono()
+
+  app.use(
+    '*',
+    cors({
+      origin: 'http://localhost:5173',
+      credentials: true,
+    }),
+  )
+
+  app.on(['POST', 'GET'], '/api/auth/**', (c) => auth.handler(c.req.raw))
+
+  return { app, auth }
+}
+
+export async function createTestUser(
+  app: Hono,
+  overrides?: { name?: string; email?: string; password?: string },
+) {
+  const name = overrides?.name ?? 'Test User'
+  const email = overrides?.email ?? 'test@example.com'
+  const password = overrides?.password ?? 'password123'
+
+  const res = await app.request('/api/auth/sign-up/email', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, email, password }),
+  })
+
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`Failed to create test user: ${res.status} ${body}`)
+  }
+
+  const data = await res.json()
+  const setCookie = res.headers.get('set-cookie')
+
+  return { user: data.user, setCookie, token: data.token }
+}
+
+export async function createAuthenticatedRequest(
+  app: Hono,
+  method: string,
+  path: string,
+  options?: {
+    cookie?: string
+    body?: unknown
+    headers?: Record<string, string>
+  },
+) {
+  const headers: Record<string, string> = {
+    ...options?.headers,
+  }
+
+  if (options?.cookie) {
+    headers['cookie'] = options.cookie
+  }
+
+  if (options?.body) {
+    headers['content-type'] = 'application/json'
+  }
+
+  return app.request(path, {
+    method,
+    headers,
+    body: options?.body ? JSON.stringify(options.body) : undefined,
+  })
+}
+
+export async function cleanupDatabase(db: PostgresJsDatabase<typeof schema>) {
+  await db.execute(sql`TRUNCATE TABLE "verification" CASCADE`)
+  await db.execute(sql`TRUNCATE TABLE "account" CASCADE`)
+  await db.execute(sql`TRUNCATE TABLE "session" CASCADE`)
+  await db.execute(sql`TRUNCATE TABLE "user" CASCADE`)
 }

--- a/apps/api/src/test/setup.ts
+++ b/apps/api/src/test/setup.ts
@@ -8,6 +8,9 @@ import { fileURLToPath } from 'node:url'
 
 let container: StartedPostgreSqlContainer
 
+// Global setup: starts a PostgreSQL container and applies the schema.
+// Individual test files should use cleanupDatabase() from helpers.ts
+// in beforeEach/afterEach to reset data between tests.
 export async function setup() {
   container = await new PostgreSqlContainer('postgres:15')
     .withDatabase('dolinear_test')


### PR DESCRIPTION
## Summary
- createTestApp(), createTestUser(), createAuthenticatedRequest(), cleanupDatabase() 헬퍼 추가
- 테스트 데이터 팩토리 (fixtures.ts) 추가
- DB 정리 패턴 표준화
- 기존 db.test.ts를 새 헬퍼 활용하도록 리팩토링

Closes #28

## Test plan
- [ ] 기존 db.test.ts 통과
- [ ] cleanupDatabase()가 모든 테이블을 정상 초기화
- [ ] createTestApp()이 Hono 앱 인스턴스를 올바르게 생성
- [ ] pnpm --filter api test 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)