### PR TITLE
feat: 워크스페이스 스키마 + API (#30)

### DIFF
--- a/apps/api/drizzle.config.ts
+++ b/apps/api/drizzle.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'drizzle-kit'
 
 export default defineConfig({
   out: './drizzle',
-  schema: ['./src/db/schema/auth.ts'],
+  schema: ['./src/db/schema/auth.ts', './src/db/schema/workspace.ts'],
   dialect: 'postgresql',
   dbCredentials: {
     url: process.env.DATABASE_URL!,

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
-    "db:push": "drizzle-kit push",
-    "db:generate": "drizzle-kit generate",
+    "db:push": "node --import tsx node_modules/drizzle-kit/bin.cjs push",
+    "db:generate": "node --import tsx node_modules/drizzle-kit/bin.cjs generate",
     "db:studio": "drizzle-kit studio",
     "test": "vitest run"
   },

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -1,1 +1,2 @@
 export * from './auth.js'
+export * from './workspace.js'

--- a/apps/api/src/db/schema/workspace.ts
+++ b/apps/api/src/db/schema/workspace.ts
@@ -1,0 +1,38 @@
+import { pgTable, text, timestamp, unique } from 'drizzle-orm/pg-core'
+import { user } from './auth.js'
+
+export const workspace = pgTable('workspace', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  slug: text('slug').notNull().unique(),
+  ownerId: text('owner_id')
+    .notNull()
+    .references(() => user.id, { onDelete: 'cascade' }),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+})
+
+export const workspaceMember = pgTable(
+  'workspace_member',
+  {
+    id: text('id').primaryKey(),
+    workspaceId: text('workspace_id')
+      .notNull()
+      .references(() => workspace.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .notNull()
+      .references(() => user.id, { onDelete: 'cascade' }),
+    role: text('role').notNull().default('member'), // 'owner' | 'admin' | 'member'
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [unique().on(table.workspaceId, table.userId)],
+)

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,7 +4,7 @@ import { cors } from 'hono/cors'
 import { serve } from '@hono/node-server'
 import { auth } from './auth.js'
 import { authMiddleware } from './middleware/auth.js'
-import { healthRoute } from './routes/index.js'
+import { healthRoute, workspacesRoute } from './routes/index.js'
 import type { Env } from './types.js'
 
 const app = new Hono<Env>()
@@ -22,6 +22,7 @@ app.use('*', authMiddleware)
 app.on(['POST', 'GET'], '/api/auth/**', (c) => auth.handler(c.req.raw))
 
 app.route('/health', healthRoute)
+app.route('/api/workspaces', workspacesRoute)
 
 serve({ fetch: app.fetch, port: 3001 }, (info) => {
   console.log(`API server running on http://localhost:${info.port}`)

--- a/apps/api/src/lib/slug.ts
+++ b/apps/api/src/lib/slug.ts
@@ -1,0 +1,20 @@
+export function generateSlug(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+}
+
+export async function generateUniqueSlug(
+  baseSlug: string,
+  existsCheck: (slug: string) => Promise<boolean>,
+): Promise<string> {
+  if (!(await existsCheck(baseSlug))) return baseSlug
+  let counter = 2
+  while (await existsCheck(`${baseSlug}-${counter}`)) {
+    counter++
+  }
+  return `${baseSlug}-${counter}`
+}

--- a/apps/api/src/middleware/workspace.ts
+++ b/apps/api/src/middleware/workspace.ts
@@ -1,0 +1,55 @@
+import { createMiddleware } from 'hono/factory'
+import { eq, and } from 'drizzle-orm'
+import { db } from '../db/index.js'
+import * as schema from '../db/schema/index.js'
+import { NotFoundError, ForbiddenError } from '../lib/errors.js'
+import type { WorkspaceEnv } from '../types.js'
+
+export function requireWorkspaceMember(allowedRoles?: string[]) {
+  return createMiddleware<WorkspaceEnv>(async (c, next) => {
+    const workspaceId = c.req.param('workspaceId')!
+
+    const ws = await db
+      .select()
+      .from(schema.workspace)
+      .where(eq(schema.workspace.id, workspaceId))
+      .limit(1)
+
+    if (ws.length === 0) {
+      throw new NotFoundError('Workspace')
+    }
+
+    const user = c.get('user')
+    const member = await db
+      .select()
+      .from(schema.workspaceMember)
+      .where(
+        and(
+          eq(schema.workspaceMember.workspaceId, workspaceId),
+          eq(schema.workspaceMember.userId, user.id),
+        ),
+      )
+      .limit(1)
+
+    if (member.length === 0) {
+      throw new ForbiddenError('Not a member of this workspace')
+    }
+
+    if (allowedRoles && !allowedRoles.includes(member[0].role)) {
+      throw new ForbiddenError('Insufficient permissions')
+    }
+
+    c.set('workspace', {
+      id: ws[0].id,
+      name: ws[0].name,
+      slug: ws[0].slug,
+      ownerId: ws[0].ownerId,
+    })
+    c.set('workspaceMember', {
+      id: member[0].id,
+      role: member[0].role,
+    })
+
+    return next()
+  })
+}

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -1,1 +1,2 @@
 export { healthRoute } from './health.js'
+export { workspacesRoute } from './workspaces.js'

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -1,0 +1,223 @@
+import { randomUUID } from 'node:crypto'
+import { Hono } from 'hono'
+import { eq, and } from 'drizzle-orm'
+import { z } from 'zod'
+import { db } from '../db/index.js'
+import * as schema from '../db/schema/index.js'
+import { validateRequest } from '../lib/validation.js'
+import { handleError, NotFoundError, ValidationError } from '../lib/errors.js'
+import { generateSlug, generateUniqueSlug } from '../lib/slug.js'
+import { requireWorkspaceMember } from '../middleware/workspace.js'
+import type { Env, WorkspaceEnv } from '../types.js'
+
+const createWorkspaceSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(50),
+})
+
+const updateWorkspaceSchema = z.object({
+  name: z.string().min(1).max(50).optional(),
+})
+
+const addMemberSchema = z.object({
+  userId: z.string().min(1, 'User ID is required'),
+  role: z.enum(['admin', 'member']),
+})
+
+export const workspacesRoute = new Hono<Env>()
+
+// POST / — Create workspace
+workspacesRoute.post('/', async (c) => {
+  const body = await validateRequest(c, createWorkspaceSchema)
+  const user = c.get('user')
+
+  const baseSlug = generateSlug(body.name)
+  const slug = await generateUniqueSlug(baseSlug, async (s) => {
+    const existing = await db
+      .select({ id: schema.workspace.id })
+      .from(schema.workspace)
+      .where(eq(schema.workspace.slug, s))
+      .limit(1)
+    return existing.length > 0
+  })
+
+  const workspaceId = randomUUID()
+  const memberId = randomUUID()
+  const now = new Date()
+
+  await db.transaction(async (tx) => {
+    await tx.insert(schema.workspace).values({
+      id: workspaceId,
+      name: body.name,
+      slug,
+      ownerId: user.id,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    await tx.insert(schema.workspaceMember).values({
+      id: memberId,
+      workspaceId,
+      userId: user.id,
+      role: 'owner',
+      createdAt: now,
+      updatedAt: now,
+    })
+  })
+
+  const [created] = await db
+    .select()
+    .from(schema.workspace)
+    .where(eq(schema.workspace.id, workspaceId))
+
+  return c.json({ data: created }, 201)
+})
+
+// GET / — List my workspaces
+workspacesRoute.get('/', async (c) => {
+  const user = c.get('user')
+
+  const rows = await db
+    .select({
+      id: schema.workspace.id,
+      name: schema.workspace.name,
+      slug: schema.workspace.slug,
+      ownerId: schema.workspace.ownerId,
+      createdAt: schema.workspace.createdAt,
+      updatedAt: schema.workspace.updatedAt,
+    })
+    .from(schema.workspaceMember)
+    .innerJoin(
+      schema.workspace,
+      eq(schema.workspaceMember.workspaceId, schema.workspace.id),
+    )
+    .where(eq(schema.workspaceMember.userId, user.id))
+
+  return c.json({ data: rows })
+})
+
+// Workspace-specific routes (require membership)
+const wsRoute = new Hono<WorkspaceEnv>()
+
+// GET /:workspaceId — Get workspace detail
+wsRoute.get('/', requireWorkspaceMember(), async (c) => {
+  const ws = c.get('workspace')
+  return c.json({ data: ws })
+})
+
+// PATCH /:workspaceId — Update workspace
+wsRoute.patch('/', requireWorkspaceMember(['owner', 'admin']), async (c) => {
+  const body = await validateRequest(c, updateWorkspaceSchema)
+  const ws = c.get('workspace')
+
+  const updateData: Record<string, unknown> = { updatedAt: new Date() }
+  if (body.name) {
+    updateData.name = body.name
+  }
+
+  await db
+    .update(schema.workspace)
+    .set(updateData)
+    .where(eq(schema.workspace.id, ws.id))
+
+  const [updated] = await db
+    .select()
+    .from(schema.workspace)
+    .where(eq(schema.workspace.id, ws.id))
+
+  return c.json({ data: updated })
+})
+
+// DELETE /:workspaceId — Delete workspace
+wsRoute.delete('/', requireWorkspaceMember(['owner']), async (c) => {
+  const ws = c.get('workspace')
+
+  await db.delete(schema.workspace).where(eq(schema.workspace.id, ws.id))
+
+  return c.json({ message: 'Workspace deleted' })
+})
+
+// POST /:workspaceId/members — Add member
+wsRoute.post(
+  '/members',
+  requireWorkspaceMember(['owner', 'admin']),
+  async (c) => {
+    const body = await validateRequest(c, addMemberSchema)
+    const ws = c.get('workspace')
+
+    // Check user exists
+    const [targetUser] = await db
+      .select()
+      .from(schema.user)
+      .where(eq(schema.user.id, body.userId))
+      .limit(1)
+
+    if (!targetUser) {
+      throw new NotFoundError('User')
+    }
+
+    // Check not already a member
+    const existing = await db
+      .select()
+      .from(schema.workspaceMember)
+      .where(
+        and(
+          eq(schema.workspaceMember.workspaceId, ws.id),
+          eq(schema.workspaceMember.userId, body.userId),
+        ),
+      )
+      .limit(1)
+
+    if (existing.length > 0) {
+      throw new ValidationError('User is already a member')
+    }
+
+    const memberId = randomUUID()
+    const now = new Date()
+
+    await db.insert(schema.workspaceMember).values({
+      id: memberId,
+      workspaceId: ws.id,
+      userId: body.userId,
+      role: body.role,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const [created] = await db
+      .select()
+      .from(schema.workspaceMember)
+      .where(eq(schema.workspaceMember.id, memberId))
+
+    return c.json({ data: created }, 201)
+  },
+)
+
+// GET /:workspaceId/members — List members
+wsRoute.get('/members', requireWorkspaceMember(), async (c) => {
+  const ws = c.get('workspace')
+
+  const members = await db
+    .select({
+      id: schema.workspaceMember.id,
+      workspaceId: schema.workspaceMember.workspaceId,
+      userId: schema.workspaceMember.userId,
+      role: schema.workspaceMember.role,
+      createdAt: schema.workspaceMember.createdAt,
+      updatedAt: schema.workspaceMember.updatedAt,
+      user: {
+        id: schema.user.id,
+        name: schema.user.name,
+        email: schema.user.email,
+        image: schema.user.image,
+      },
+    })
+    .from(schema.workspaceMember)
+    .innerJoin(schema.user, eq(schema.workspaceMember.userId, schema.user.id))
+    .where(eq(schema.workspaceMember.workspaceId, ws.id))
+
+  return c.json({ data: members })
+})
+
+workspacesRoute.route('/:workspaceId', wsRoute)
+
+workspacesRoute.onError(handleError)

--- a/apps/api/src/test/fixtures.ts
+++ b/apps/api/src/test/fixtures.ts
@@ -1,5 +1,11 @@
 import { randomUUID } from 'node:crypto'
-import type { User, Workspace, Team, Issue } from '@dolinear/shared'
+import type {
+  User,
+  Workspace,
+  WorkspaceMember,
+  Team,
+  Issue,
+} from '@dolinear/shared'
 
 export function buildUser(overrides?: Partial<User>): User {
   return {
@@ -20,6 +26,20 @@ export function buildWorkspace(overrides?: Partial<Workspace>): Workspace {
     name: 'Test Workspace',
     slug: `workspace-${randomUUID().slice(0, 8)}`,
     ownerId: randomUUID(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}
+
+export function buildWorkspaceMember(
+  overrides?: Partial<WorkspaceMember>,
+): WorkspaceMember {
+  return {
+    id: randomUUID(),
+    workspaceId: randomUUID(),
+    userId: randomUUID(),
+    role: 'member',
     createdAt: new Date(),
     updatedAt: new Date(),
     ...overrides,

--- a/apps/api/src/test/routes/workspaces.test.ts
+++ b/apps/api/src/test/routes/workspaces.test.ts
@@ -1,0 +1,457 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { Hono } from 'hono'
+import { cors } from 'hono/cors'
+import { auth } from '../../auth.js'
+import { authMiddleware } from '../../middleware/auth.js'
+import { workspacesRoute } from '../../routes/workspaces.js'
+import { createTestDb, cleanupDatabase } from '../helpers.js'
+import { createAuthenticatedUser } from '../auth-helpers.js'
+import type { Env } from '../../types.js'
+
+describe('Workspace Routes', () => {
+  const { db, client } = createTestDb()
+
+  function createApp() {
+    const app = new Hono<Env>()
+
+    app.use(
+      '*',
+      cors({
+        origin: 'http://localhost:5173',
+        credentials: true,
+      }),
+    )
+
+    app.on(['POST', 'GET'], '/api/auth/**', (c) => auth.handler(c.req.raw))
+    app.use('*', authMiddleware)
+    app.route('/api/workspaces', workspacesRoute)
+
+    return app
+  }
+
+  beforeEach(async () => {
+    await cleanupDatabase(db)
+  })
+
+  afterAll(async () => {
+    await client.end()
+  })
+
+  function request(
+    app: Hono<Env>,
+    method: string,
+    path: string,
+    cookieHeader: string,
+    body?: unknown,
+  ) {
+    const headers: Record<string, string> = {
+      Cookie: cookieHeader,
+    }
+    if (body) {
+      headers['Content-Type'] = 'application/json'
+    }
+    return app.request(path, {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+    })
+  }
+
+  async function createWorkspace(
+    app: Hono<Env>,
+    cookieHeader: string,
+    name = 'Test Workspace',
+  ) {
+    const res = await request(app, 'POST', '/api/workspaces', cookieHeader, {
+      name,
+    })
+    const data = await res.json()
+    return { res, data }
+  }
+
+  describe('POST /api/workspaces', () => {
+    it('should create a workspace', async () => {
+      const app = createApp()
+      const { cookieHeader } = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const { res, data } = await createWorkspace(
+        app,
+        cookieHeader,
+        'My Workspace',
+      )
+
+      expect(res.status).toBe(201)
+      expect(data.data.name).toBe('My Workspace')
+      expect(data.data.slug).toBe('my-workspace')
+      expect(data.data.id).toBeDefined()
+    })
+
+    it('should auto-generate unique slugs', async () => {
+      const app = createApp()
+      const { cookieHeader } = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+
+      const { data: first } = await createWorkspace(
+        app,
+        cookieHeader,
+        'My Workspace',
+      )
+      expect(first.data.slug).toBe('my-workspace')
+
+      const { data: second } = await createWorkspace(
+        app,
+        cookieHeader,
+        'My Workspace',
+      )
+      expect(second.data.slug).toBe('my-workspace-2')
+    })
+
+    it('should add creator as owner member', async () => {
+      const app = createApp()
+      const { cookieHeader } = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const { data } = await createWorkspace(app, cookieHeader)
+
+      const membersRes = await request(
+        app,
+        'GET',
+        `/api/workspaces/${data.data.id}/members`,
+        cookieHeader,
+      )
+      const members = await membersRes.json()
+
+      expect(members.data).toHaveLength(1)
+      expect(members.data[0].role).toBe('owner')
+    })
+
+    it('should return 400 for missing name', async () => {
+      const app = createApp()
+      const { cookieHeader } = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const res = await request(
+        app,
+        'POST',
+        '/api/workspaces',
+        cookieHeader,
+        {},
+      )
+
+      expect(res.status).toBe(400)
+    })
+  })
+
+  describe('GET /api/workspaces', () => {
+    it('should list only my workspaces', async () => {
+      const app = createApp()
+      const user1 = await createAuthenticatedUser(app, {
+        email: 'user1@test.com',
+      })
+      const user2 = await createAuthenticatedUser(app, {
+        email: 'user2@test.com',
+      })
+
+      await createWorkspace(app, user1.cookieHeader, 'Workspace 1')
+      await createWorkspace(app, user2.cookieHeader, 'Workspace 2')
+
+      const res = await request(
+        app,
+        'GET',
+        '/api/workspaces',
+        user1.cookieHeader,
+      )
+      const data = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(data.data).toHaveLength(1)
+      expect(data.data[0].name).toBe('Workspace 1')
+    })
+  })
+
+  describe('GET /api/workspaces/:workspaceId', () => {
+    it('should return workspace detail for member', async () => {
+      const app = createApp()
+      const { cookieHeader } = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const { data } = await createWorkspace(app, cookieHeader)
+
+      const res = await request(
+        app,
+        'GET',
+        `/api/workspaces/${data.data.id}`,
+        cookieHeader,
+      )
+      const detail = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(detail.data.id).toBe(data.data.id)
+    })
+
+    it('should return 403 for non-member', async () => {
+      const app = createApp()
+      const owner = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const other = await createAuthenticatedUser(app, {
+        email: 'other@test.com',
+      })
+
+      const { data } = await createWorkspace(app, owner.cookieHeader)
+
+      const res = await request(
+        app,
+        'GET',
+        `/api/workspaces/${data.data.id}`,
+        other.cookieHeader,
+      )
+
+      expect(res.status).toBe(403)
+    })
+  })
+
+  describe('PATCH /api/workspaces/:workspaceId', () => {
+    it('should update workspace name for owner', async () => {
+      const app = createApp()
+      const { cookieHeader } = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const { data } = await createWorkspace(app, cookieHeader)
+
+      const res = await request(
+        app,
+        'PATCH',
+        `/api/workspaces/${data.data.id}`,
+        cookieHeader,
+        { name: 'Updated Name' },
+      )
+      const updated = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(updated.data.name).toBe('Updated Name')
+    })
+
+    it('should return 403 for member without admin/owner role', async () => {
+      const app = createApp()
+      const owner = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const member = await createAuthenticatedUser(app, {
+        email: 'member@test.com',
+      })
+
+      const { data } = await createWorkspace(app, owner.cookieHeader)
+
+      // Get member's user id
+      const memberSessionRes = await app.request('/api/auth/get-session', {
+        headers: { Cookie: member.cookieHeader },
+      })
+      const memberSession = await memberSessionRes.json()
+
+      // Add member with 'member' role
+      await request(
+        app,
+        'POST',
+        `/api/workspaces/${data.data.id}/members`,
+        owner.cookieHeader,
+        { userId: memberSession.user.id, role: 'member' },
+      )
+
+      const res = await request(
+        app,
+        'PATCH',
+        `/api/workspaces/${data.data.id}`,
+        member.cookieHeader,
+        { name: 'Hacked' },
+      )
+
+      expect(res.status).toBe(403)
+    })
+  })
+
+  describe('DELETE /api/workspaces/:workspaceId', () => {
+    it('should delete workspace for owner', async () => {
+      const app = createApp()
+      const { cookieHeader } = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const { data } = await createWorkspace(app, cookieHeader)
+
+      const res = await request(
+        app,
+        'DELETE',
+        `/api/workspaces/${data.data.id}`,
+        cookieHeader,
+      )
+
+      expect(res.status).toBe(200)
+
+      const listRes = await request(app, 'GET', '/api/workspaces', cookieHeader)
+      const listData = await listRes.json()
+      expect(listData.data).toHaveLength(0)
+    })
+
+    it('should return 403 for non-owner', async () => {
+      const app = createApp()
+      const owner = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const admin = await createAuthenticatedUser(app, {
+        email: 'admin@test.com',
+      })
+
+      const { data } = await createWorkspace(app, owner.cookieHeader)
+
+      const adminSessionRes = await app.request('/api/auth/get-session', {
+        headers: { Cookie: admin.cookieHeader },
+      })
+      const adminSession = await adminSessionRes.json()
+
+      await request(
+        app,
+        'POST',
+        `/api/workspaces/${data.data.id}/members`,
+        owner.cookieHeader,
+        { userId: adminSession.user.id, role: 'admin' },
+      )
+
+      const res = await request(
+        app,
+        'DELETE',
+        `/api/workspaces/${data.data.id}`,
+        admin.cookieHeader,
+      )
+
+      expect(res.status).toBe(403)
+    })
+  })
+
+  describe('POST /api/workspaces/:workspaceId/members', () => {
+    it('should add member as owner', async () => {
+      const app = createApp()
+      const owner = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const newUser = await createAuthenticatedUser(app, {
+        email: 'new@test.com',
+      })
+
+      const { data } = await createWorkspace(app, owner.cookieHeader)
+
+      const sessionRes = await app.request('/api/auth/get-session', {
+        headers: { Cookie: newUser.cookieHeader },
+      })
+      const session = await sessionRes.json()
+
+      const res = await request(
+        app,
+        'POST',
+        `/api/workspaces/${data.data.id}/members`,
+        owner.cookieHeader,
+        { userId: session.user.id, role: 'member' },
+      )
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body.data.role).toBe('member')
+    })
+
+    it('should return 403 for member trying to add', async () => {
+      const app = createApp()
+      const owner = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const member = await createAuthenticatedUser(app, {
+        email: 'member@test.com',
+      })
+      const another = await createAuthenticatedUser(app, {
+        email: 'another@test.com',
+      })
+
+      const { data } = await createWorkspace(app, owner.cookieHeader)
+
+      const memberSessionRes = await app.request('/api/auth/get-session', {
+        headers: { Cookie: member.cookieHeader },
+      })
+      const memberSession = await memberSessionRes.json()
+
+      const anotherSessionRes = await app.request('/api/auth/get-session', {
+        headers: { Cookie: another.cookieHeader },
+      })
+      const anotherSession = await anotherSessionRes.json()
+
+      await request(
+        app,
+        'POST',
+        `/api/workspaces/${data.data.id}/members`,
+        owner.cookieHeader,
+        { userId: memberSession.user.id, role: 'member' },
+      )
+
+      const res = await request(
+        app,
+        'POST',
+        `/api/workspaces/${data.data.id}/members`,
+        member.cookieHeader,
+        { userId: anotherSession.user.id, role: 'member' },
+      )
+
+      expect(res.status).toBe(403)
+    })
+
+    it('should not allow setting owner role', async () => {
+      const app = createApp()
+      const owner = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const newUser = await createAuthenticatedUser(app, {
+        email: 'new@test.com',
+      })
+
+      const { data } = await createWorkspace(app, owner.cookieHeader)
+
+      const sessionRes = await app.request('/api/auth/get-session', {
+        headers: { Cookie: newUser.cookieHeader },
+      })
+      const session = await sessionRes.json()
+
+      const res = await request(
+        app,
+        'POST',
+        `/api/workspaces/${data.data.id}/members`,
+        owner.cookieHeader,
+        { userId: session.user.id, role: 'owner' },
+      )
+
+      expect(res.status).toBe(400)
+    })
+  })
+
+  describe('GET /api/workspaces/:workspaceId/members', () => {
+    it('should list members with user info', async () => {
+      const app = createApp()
+      const owner = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+        name: 'Owner',
+      })
+      const { data } = await createWorkspace(app, owner.cookieHeader)
+
+      const res = await request(
+        app,
+        'GET',
+        `/api/workspaces/${data.data.id}/members`,
+        owner.cookieHeader,
+      )
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.data).toHaveLength(1)
+      expect(body.data[0].user).toBeDefined()
+      expect(body.data[0].user.email).toBe('owner@test.com')
+      expect(body.data[0].user.name).toBe('Owner')
+    })
+  })
+})

--- a/apps/api/src/test/setup.ts
+++ b/apps/api/src/test/setup.ts
@@ -26,7 +26,7 @@ export async function setup() {
     path.dirname(fileURLToPath(import.meta.url)),
     '../..',
   )
-  execSync('pnpm exec drizzle-kit push --force', {
+  execSync('node --import tsx node_modules/drizzle-kit/bin.cjs push --force', {
     cwd: apiDir,
     env: { ...process.env, DATABASE_URL: connectionString },
     stdio: 'pipe',

--- a/apps/api/src/test/slug.test.ts
+++ b/apps/api/src/test/slug.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { generateSlug, generateUniqueSlug } from '../lib/slug.js'
+
+describe('generateSlug', () => {
+  it('should convert name to lowercase kebab-case', () => {
+    expect(generateSlug('My Workspace')).toBe('my-workspace')
+  })
+
+  it('should replace special characters with hyphens', () => {
+    expect(generateSlug('Hello World! @#$')).toBe('hello-world')
+  })
+
+  it('should trim whitespace', () => {
+    expect(generateSlug('  spaced  ')).toBe('spaced')
+  })
+
+  it('should collapse multiple hyphens', () => {
+    expect(generateSlug('a---b---c')).toBe('a-b-c')
+  })
+
+  it('should remove leading and trailing hyphens', () => {
+    expect(generateSlug('---hello---')).toBe('hello')
+  })
+
+  it('should handle unicode characters', () => {
+    expect(generateSlug('café résumé')).toBe('caf-r-sum')
+  })
+
+  it('should handle numbers', () => {
+    expect(generateSlug('Team 42')).toBe('team-42')
+  })
+})
+
+describe('generateUniqueSlug', () => {
+  it('should return base slug when it does not exist', async () => {
+    const slug = await generateUniqueSlug('my-workspace', async () => false)
+    expect(slug).toBe('my-workspace')
+  })
+
+  it('should append counter when base slug exists', async () => {
+    const existing = new Set(['my-workspace'])
+    const slug = await generateUniqueSlug('my-workspace', async (s) =>
+      existing.has(s),
+    )
+    expect(slug).toBe('my-workspace-2')
+  })
+
+  it('should increment counter until unique slug is found', async () => {
+    const existing = new Set([
+      'my-workspace',
+      'my-workspace-2',
+      'my-workspace-3',
+    ])
+    const slug = await generateUniqueSlug('my-workspace', async (s) =>
+      existing.has(s),
+    )
+    expect(slug).toBe('my-workspace-4')
+  })
+})

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -8,3 +8,10 @@ export type Env = {
     session: Session['session']
   }
 }
+
+export type WorkspaceEnv = {
+  Variables: Env['Variables'] & {
+    workspace: { id: string; name: string; slug: string; ownerId: string }
+    workspaceMember: { id: string; role: string }
+  }
+}

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -7,5 +7,6 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     testTimeout: 30_000,
     hookTimeout: 60_000,
+    fileParallelism: false,
   },
 })

--- a/packages/shared/src/types/workspace.ts
+++ b/packages/shared/src/types/workspace.ts
@@ -6,3 +6,14 @@ export interface Workspace {
   createdAt: Date
   updatedAt: Date
 }
+
+export type WorkspaceMemberRole = 'owner' | 'admin' | 'member'
+
+export interface WorkspaceMember {
+  id: string
+  workspaceId: string
+  userId: string
+  role: WorkspaceMemberRole
+  createdAt: Date
+  updatedAt: Date
+}


### PR DESCRIPTION
## Summary

- 워크스페이스 및 워크스페이스 멤버 DB 스키마 추가 (`workspace`, `workspace_member` 테이블)
- 워크스페이스 CRUD API 구현 (`POST/GET/PATCH/DELETE /api/workspaces`)
- 멤버 관리 API 구현 (`POST/GET /api/workspaces/:workspaceId/members`)
- `requireWorkspaceMember` 미들웨어로 역할 기반 접근 제어 (owner/admin/member)
- slug 자동 생성 유틸리티 (kebab-case + 중복 시 자동 suffix)
- `WorkspaceMember`, `WorkspaceMemberRole` 공유 타입 추가
- drizzle-kit ESM 호환 수정 (`node --import tsx`)
- vitest `fileParallelism: false` 설정으로 테스트 DB 충돌 방지

Closes #30

## Test plan
- [x] `pnpm --filter api test` — 47 tests 전체 통과 (slug 단위 10 + workspace 통합 15 + 기존 22)
- [x] `pnpm build` — 빌드 성공
- [x] `pnpm lint` — 린트 에러 없음
- [x] 워크스페이스 생성 시 slug 자동 생성 확인
- [x] 중복 slug 시 suffix 추가 확인
- [x] 비멤버 접근 시 403 반환 확인
- [x] owner/admin/member 권한별 동작 차이 확인
- [x] 멤버 추가/조회 API 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)