### PR TITLE
fix: API 서버 graceful shutdown 구현

### DIFF
--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -4,5 +4,5 @@ import * as schema from './schema/index.js'
 
 const connectionString = process.env.DATABASE_URL!
 
-const client = postgres(connectionString)
+export const client = postgres(connectionString)
 export const db = drizzle(client, { schema })

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 import { serve } from '@hono/node-server'
 import { auth } from './auth.js'
+import { client } from './db/index.js'
 import { authMiddleware } from './middleware/auth.js'
 import { healthRoute, workspacesRoute } from './routes/index.js'
 import type { Env } from './types.js'
@@ -24,6 +25,22 @@ app.on(['POST', 'GET'], '/api/auth/**', (c) => auth.handler(c.req.raw))
 app.route('/health', healthRoute)
 app.route('/api/workspaces', workspacesRoute)
 
-serve({ fetch: app.fetch, port: 3001 }, (info) => {
+const server = serve({ fetch: app.fetch, port: 3001 }, (info) => {
   console.log(`API server running on http://localhost:${info.port}`)
 })
+
+let isShuttingDown = false
+
+function shutdown() {
+  if (isShuttingDown) return
+  isShuttingDown = true
+  console.log('\nShutting down gracefully...')
+  server.close(async () => {
+    await client.end()
+    console.log('Server stopped')
+    process.exit(0)
+  })
+}
+
+process.on('SIGINT', shutdown)
+process.on('SIGTERM', shutdown)


### PR DESCRIPTION
## Summary
- SIGINT/SIGTERM 시그널 핸들러를 추가하여 Ctrl-C 시 graceful shutdown 구현
- HTTP 서버 close → DB 연결 end → process.exit(0) 순서 보장
- 중복 shutdown 호출 방지를 위한 isShuttingDown 플래그 추가
- `db/index.ts`에서 postgres client를 export하여 shutdown 시 접근 가능

## Test plan
- [ ] `pnpm --filter api test` — 테스트 통과
- [ ] `pnpm dev` → Ctrl-C → "Shutting down gracefully..." + "Server stopped" 출력 확인
- [ ] 프로세스 exit code 0 확인
- [ ] `lsof -i :3001` — 좀비 프로세스 없음 확인
- [ ] `pnpm build` — 모노레포 전체 빌드

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)