### PR TITLE
feat: 팀 스키마 및 CRUD API 구현

### DIFF
--- a/apps/api/drizzle.config.ts
+++ b/apps/api/drizzle.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     './src/db/schema/auth.ts',
     './src/db/schema/workspace.ts',
     './src/db/schema/label.ts',
+    './src/db/schema/team.ts',
   ],
   dialect: 'postgresql',
   dbCredentials: {

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -1,3 +1,4 @@
 export * from './auth.ts'
 export * from './workspace.ts'
 export * from './label.ts'
+export * from './team.ts'

--- a/apps/api/src/db/schema/team.ts
+++ b/apps/api/src/db/schema/team.ts
@@ -1,0 +1,43 @@
+import { pgTable, text, timestamp, integer, unique } from 'drizzle-orm/pg-core'
+import { workspace } from './workspace.ts'
+import { user } from './auth.ts'
+
+export const team = pgTable(
+  'team',
+  {
+    id: text('id').primaryKey(),
+    workspaceId: text('workspace_id')
+      .notNull()
+      .references(() => workspace.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    identifier: text('identifier').notNull(),
+    issueCounter: integer('issue_counter').notNull().default(0),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [unique().on(table.workspaceId, table.identifier)],
+)
+
+export const teamMember = pgTable(
+  'team_member',
+  {
+    id: text('id').primaryKey(),
+    teamId: text('team_id')
+      .notNull()
+      .references(() => team.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .notNull()
+      .references(() => user.id, { onDelete: 'cascade' }),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [unique().on(table.teamId, table.userId)],
+)

--- a/apps/api/src/lib/errors.ts
+++ b/apps/api/src/lib/errors.ts
@@ -54,6 +54,13 @@ export class ForbiddenError extends AppError {
   }
 }
 
+export class ConflictError extends AppError {
+  constructor(message: string) {
+    super(409, message)
+    this.name = 'ConflictError'
+  }
+}
+
 export function handleError(err: Error, c: Context) {
   if (err instanceof AppError) {
     return c.json(err.toResponse(), err.statusCode as 400)

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -1,3 +1,4 @@
 export { healthRoute } from './health.ts'
 export { workspacesRoute } from './workspaces.ts'
 export { labelsRoute } from './labels.ts'
+export { teamsRoute } from './teams.ts'

--- a/apps/api/src/routes/teams.ts
+++ b/apps/api/src/routes/teams.ts
@@ -1,0 +1,307 @@
+import { randomUUID } from 'node:crypto'
+import { Hono } from 'hono'
+import { eq, and } from 'drizzle-orm'
+import { z } from 'zod'
+import { db } from '../db/index.ts'
+import * as schema from '../db/schema/index.ts'
+import { validateRequest } from '../lib/validation.ts'
+import {
+  handleError,
+  NotFoundError,
+  ValidationError,
+  ConflictError,
+  ForbiddenError,
+} from '../lib/errors.ts'
+import { requireWorkspaceMember } from '../middleware/workspace.ts'
+import type { WorkspaceEnv } from '../types.ts'
+
+const IDENTIFIER_REGEX = /^[A-Z]{2,5}$/
+
+const createTeamSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(50),
+  identifier: z
+    .string()
+    .regex(IDENTIFIER_REGEX, 'Identifier must be 2-5 uppercase letters'),
+})
+
+const updateTeamSchema = z.object({
+  name: z.string().min(1).max(50).optional(),
+})
+
+const addMemberSchema = z.object({
+  userId: z.string().min(1, 'User ID is required'),
+})
+
+// Teams are always nested under a workspace: /api/workspaces/:workspaceId/teams
+export const teamsRoute = new Hono<WorkspaceEnv>()
+
+// POST / — Create team
+teamsRoute.post('/', requireWorkspaceMember(['owner', 'admin']), async (c) => {
+  const body = await validateRequest(c, createTeamSchema)
+  const ws = c.get('workspace')
+  const user = c.get('user')
+
+  // Validate identifier format (extra safety on top of zod)
+  if (!IDENTIFIER_REGEX.test(body.identifier)) {
+    throw new ValidationError('Identifier must be 2-5 uppercase letters')
+  }
+
+  // Check identifier uniqueness within workspace
+  const existing = await db
+    .select({ id: schema.team.id })
+    .from(schema.team)
+    .where(
+      and(
+        eq(schema.team.workspaceId, ws.id),
+        eq(schema.team.identifier, body.identifier),
+      ),
+    )
+    .limit(1)
+
+  if (existing.length > 0) {
+    throw new ConflictError(
+      `Team with identifier '${body.identifier}' already exists in this workspace`,
+    )
+  }
+
+  const teamId = randomUUID()
+  const memberId = randomUUID()
+  const now = new Date()
+
+  await db.transaction(async (tx) => {
+    await tx.insert(schema.team).values({
+      id: teamId,
+      workspaceId: ws.id,
+      name: body.name,
+      identifier: body.identifier,
+      issueCounter: 0,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    // Auto-add creator as team member
+    await tx.insert(schema.teamMember).values({
+      id: memberId,
+      teamId,
+      userId: user.id,
+      createdAt: now,
+      updatedAt: now,
+    })
+  })
+
+  const [created] = await db
+    .select()
+    .from(schema.team)
+    .where(eq(schema.team.id, teamId))
+
+  return c.json({ data: created }, 201)
+})
+
+// GET / — List teams in workspace
+teamsRoute.get('/', requireWorkspaceMember(), async (c) => {
+  const ws = c.get('workspace')
+
+  const teams = await db
+    .select()
+    .from(schema.team)
+    .where(eq(schema.team.workspaceId, ws.id))
+
+  return c.json({ data: teams })
+})
+
+// GET /:teamId — Get team detail
+teamsRoute.get('/:teamId', requireWorkspaceMember(), async (c) => {
+  const ws = c.get('workspace')
+  const teamId = c.req.param('teamId')!
+
+  const [teamRow] = await db
+    .select()
+    .from(schema.team)
+    .where(and(eq(schema.team.id, teamId), eq(schema.team.workspaceId, ws.id)))
+    .limit(1)
+
+  if (!teamRow) {
+    throw new NotFoundError('Team')
+  }
+
+  return c.json({ data: teamRow })
+})
+
+// PATCH /:teamId — Update team
+teamsRoute.patch(
+  '/:teamId',
+  requireWorkspaceMember(['owner', 'admin']),
+  async (c) => {
+    const body = await validateRequest(c, updateTeamSchema)
+    const ws = c.get('workspace')
+    const teamId = c.req.param('teamId')!
+
+    const [teamRow] = await db
+      .select()
+      .from(schema.team)
+      .where(
+        and(eq(schema.team.id, teamId), eq(schema.team.workspaceId, ws.id)),
+      )
+      .limit(1)
+
+    if (!teamRow) {
+      throw new NotFoundError('Team')
+    }
+
+    const updateData: Record<string, unknown> = { updatedAt: new Date() }
+    if (body.name) {
+      updateData.name = body.name
+    }
+
+    await db
+      .update(schema.team)
+      .set(updateData)
+      .where(eq(schema.team.id, teamId))
+
+    const [updated] = await db
+      .select()
+      .from(schema.team)
+      .where(eq(schema.team.id, teamId))
+
+    return c.json({ data: updated })
+  },
+)
+
+// DELETE /:teamId — Delete team
+teamsRoute.delete(
+  '/:teamId',
+  requireWorkspaceMember(['owner', 'admin']),
+  async (c) => {
+    const ws = c.get('workspace')
+    const teamId = c.req.param('teamId')!
+
+    const [teamRow] = await db
+      .select()
+      .from(schema.team)
+      .where(
+        and(eq(schema.team.id, teamId), eq(schema.team.workspaceId, ws.id)),
+      )
+      .limit(1)
+
+    if (!teamRow) {
+      throw new NotFoundError('Team')
+    }
+
+    await db.delete(schema.team).where(eq(schema.team.id, teamId))
+
+    return c.json({ message: 'Team deleted' })
+  },
+)
+
+// POST /:teamId/members — Add team member
+teamsRoute.post(
+  '/:teamId/members',
+  requireWorkspaceMember(['owner', 'admin']),
+  async (c) => {
+    const body = await validateRequest(c, addMemberSchema)
+    const ws = c.get('workspace')
+    const teamId = c.req.param('teamId')!
+
+    // Check team exists in this workspace
+    const [teamRow] = await db
+      .select()
+      .from(schema.team)
+      .where(
+        and(eq(schema.team.id, teamId), eq(schema.team.workspaceId, ws.id)),
+      )
+      .limit(1)
+
+    if (!teamRow) {
+      throw new NotFoundError('Team')
+    }
+
+    // Check target user is a workspace member
+    const [wsMember] = await db
+      .select()
+      .from(schema.workspaceMember)
+      .where(
+        and(
+          eq(schema.workspaceMember.workspaceId, ws.id),
+          eq(schema.workspaceMember.userId, body.userId),
+        ),
+      )
+      .limit(1)
+
+    if (!wsMember) {
+      throw new ForbiddenError('User is not a member of this workspace')
+    }
+
+    // Check not already a team member
+    const existingMember = await db
+      .select()
+      .from(schema.teamMember)
+      .where(
+        and(
+          eq(schema.teamMember.teamId, teamId),
+          eq(schema.teamMember.userId, body.userId),
+        ),
+      )
+      .limit(1)
+
+    if (existingMember.length > 0) {
+      throw new ConflictError('User is already a member of this team')
+    }
+
+    const memberId = randomUUID()
+    const now = new Date()
+
+    await db.insert(schema.teamMember).values({
+      id: memberId,
+      teamId,
+      userId: body.userId,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const [created] = await db
+      .select()
+      .from(schema.teamMember)
+      .where(eq(schema.teamMember.id, memberId))
+
+    return c.json({ data: created }, 201)
+  },
+)
+
+// GET /:teamId/members — List team members
+teamsRoute.get('/:teamId/members', requireWorkspaceMember(), async (c) => {
+  const ws = c.get('workspace')
+  const teamId = c.req.param('teamId')!
+
+  // Check team exists in this workspace
+  const [teamRow] = await db
+    .select()
+    .from(schema.team)
+    .where(and(eq(schema.team.id, teamId), eq(schema.team.workspaceId, ws.id)))
+    .limit(1)
+
+  if (!teamRow) {
+    throw new NotFoundError('Team')
+  }
+
+  const members = await db
+    .select({
+      id: schema.teamMember.id,
+      teamId: schema.teamMember.teamId,
+      userId: schema.teamMember.userId,
+      createdAt: schema.teamMember.createdAt,
+      updatedAt: schema.teamMember.updatedAt,
+      user: {
+        id: schema.user.id,
+        name: schema.user.name,
+        email: schema.user.email,
+        image: schema.user.image,
+      },
+    })
+    .from(schema.teamMember)
+    .innerJoin(schema.user, eq(schema.teamMember.userId, schema.user.id))
+    .where(eq(schema.teamMember.teamId, teamId))
+
+  return c.json({ data: members })
+})
+
+teamsRoute.onError(handleError)

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -9,6 +9,7 @@ import { handleError, NotFoundError, ValidationError } from '../lib/errors.ts'
 import { generateSlug, generateUniqueSlug } from '../lib/slug.ts'
 import { requireWorkspaceMember } from '../middleware/workspace.ts'
 import { labelsRoute } from './labels.ts'
+import { teamsRoute } from './teams.ts'
 import type { Env, WorkspaceEnv } from '../types.ts'
 
 const createWorkspaceSchema = z.object({
@@ -220,6 +221,7 @@ wsRoute.get('/members', requireWorkspaceMember(), async (c) => {
 })
 
 wsRoute.route('/labels', labelsRoute)
+wsRoute.route('/teams', teamsRoute)
 
 workspacesRoute.route('/:workspaceId', wsRoute)
 

--- a/apps/api/src/test/fixtures.ts
+++ b/apps/api/src/test/fixtures.ts
@@ -50,7 +50,8 @@ export function buildTeam(overrides?: Partial<Team>): Team {
   return {
     id: randomUUID(),
     name: 'Test Team',
-    identifier: `TM-${randomUUID().slice(0, 4).toUpperCase()}`,
+    identifier: 'TST',
+    issueCounter: 0,
     workspaceId: randomUUID(),
     createdAt: new Date(),
     updatedAt: new Date(),

--- a/apps/api/src/test/helpers.ts
+++ b/apps/api/src/test/helpers.ts
@@ -132,6 +132,8 @@ export async function createAuthenticatedRequest(
 
 export async function cleanupDatabase(db: PostgresJsDatabase<typeof schema>) {
   await db.execute(sql`TRUNCATE TABLE "label" CASCADE`)
+  await db.execute(sql`TRUNCATE TABLE "team_member" CASCADE`)
+  await db.execute(sql`TRUNCATE TABLE "team" CASCADE`)
   await db.execute(sql`TRUNCATE TABLE "workspace_member" CASCADE`)
   await db.execute(sql`TRUNCATE TABLE "workspace" CASCADE`)
   await db.execute(sql`TRUNCATE TABLE "verification" CASCADE`)

--- a/apps/api/src/test/routes/teams.test.ts
+++ b/apps/api/src/test/routes/teams.test.ts
@@ -1,0 +1,594 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { Hono } from 'hono'
+import { cors } from 'hono/cors'
+import { auth } from '../../auth.ts'
+import { authMiddleware } from '../../middleware/auth.ts'
+import { workspacesRoute } from '../../routes/workspaces.ts'
+import { createTestDb, cleanupDatabase } from '../helpers.ts'
+import { createAuthenticatedUser } from '../auth-helpers.ts'
+import type { Env } from '../../types.ts'
+
+describe('Team Routes', () => {
+  const { db, client } = createTestDb()
+
+  function createApp() {
+    const app = new Hono<Env>()
+
+    app.use(
+      '*',
+      cors({
+        origin: 'http://localhost:5173',
+        credentials: true,
+      }),
+    )
+
+    app.on(['POST', 'GET'], '/api/auth/**', (c) => auth.handler(c.req.raw))
+    app.use('*', authMiddleware)
+    app.route('/api/workspaces', workspacesRoute)
+
+    return app
+  }
+
+  beforeEach(async () => {
+    await cleanupDatabase(db)
+  })
+
+  afterAll(async () => {
+    await client.end()
+  })
+
+  function request(
+    app: Hono<Env>,
+    method: string,
+    path: string,
+    cookieHeader: string,
+    body?: unknown,
+  ) {
+    const headers: Record<string, string> = {
+      Cookie: cookieHeader,
+    }
+    if (body) {
+      headers['Content-Type'] = 'application/json'
+    }
+    return app.request(path, {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+    })
+  }
+
+  async function createWorkspace(
+    app: Hono<Env>,
+    cookieHeader: string,
+    name = 'Test Workspace',
+  ) {
+    const res = await request(app, 'POST', '/api/workspaces', cookieHeader, {
+      name,
+    })
+    const data = await res.json()
+    return { res, data }
+  }
+
+  async function createTeam(
+    app: Hono<Env>,
+    cookieHeader: string,
+    workspaceId: string,
+    options?: { name?: string; identifier?: string },
+  ) {
+    const name = options?.name ?? 'Engineering'
+    const identifier = options?.identifier ?? 'ENG'
+    const res = await request(
+      app,
+      'POST',
+      `/api/workspaces/${workspaceId}/teams`,
+      cookieHeader,
+      { name, identifier },
+    )
+    const data = await res.json()
+    return { res, data }
+  }
+
+  async function getUserId(app: Hono<Env>, cookieHeader: string) {
+    const sessionRes = await app.request('/api/auth/get-session', {
+      headers: { Cookie: cookieHeader },
+    })
+    const session = await sessionRes.json()
+    return session.user.id as string
+  }
+
+  describe('POST /api/workspaces/:workspaceId/teams', () => {
+    it('should create a team', async () => {
+      const app = createApp()
+      const { cookieHeader } = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const { data: ws } = await createWorkspace(app, cookieHeader)
+
+      const { res, data } = await createTeam(app, cookieHeader, ws.data.id, {
+        name: 'Engineering',
+        identifier: 'ENG',
+      })
+
+      expect(res.status).toBe(201)
+      expect(data.data.name).toBe('Engineering')
+      expect(data.data.identifier).toBe('ENG')
+      expect(data.data.workspaceId).toBe(ws.data.id)
+      expect(data.data.issueCounter).toBe(0)
+      expect(data.data.id).toBeDefined()
+    })
+
+    it('should return 409 for duplicate identifier in same workspace', async () => {
+      const app = createApp()
+      const { cookieHeader } = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const { data: ws } = await createWorkspace(app, cookieHeader)
+
+      await createTeam(app, cookieHeader, ws.data.id, {
+        name: 'Engineering',
+        identifier: 'ENG',
+      })
+
+      const { res, data } = await createTeam(app, cookieHeader, ws.data.id, {
+        name: 'Engineering 2',
+        identifier: 'ENG',
+      })
+
+      expect(res.status).toBe(409)
+      expect(data.message).toContain('ENG')
+    })
+
+    it('should allow same identifier in different workspaces', async () => {
+      const app = createApp()
+      const { cookieHeader } = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+
+      const { data: ws1 } = await createWorkspace(
+        app,
+        cookieHeader,
+        'Workspace 1',
+      )
+      const { data: ws2 } = await createWorkspace(
+        app,
+        cookieHeader,
+        'Workspace 2',
+      )
+
+      const { res: res1 } = await createTeam(app, cookieHeader, ws1.data.id, {
+        identifier: 'ENG',
+      })
+      const { res: res2 } = await createTeam(app, cookieHeader, ws2.data.id, {
+        identifier: 'ENG',
+      })
+
+      expect(res1.status).toBe(201)
+      expect(res2.status).toBe(201)
+    })
+
+    it('should return 400 for invalid identifier format', async () => {
+      const app = createApp()
+      const { cookieHeader } = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const { data: ws } = await createWorkspace(app, cookieHeader)
+
+      // Too short (1 char)
+      const { res: res1 } = await createTeam(app, cookieHeader, ws.data.id, {
+        identifier: 'A',
+      })
+      expect(res1.status).toBe(400)
+
+      // Too long (6 chars)
+      const { res: res2 } = await createTeam(app, cookieHeader, ws.data.id, {
+        identifier: 'ABCDEF',
+      })
+      expect(res2.status).toBe(400)
+
+      // Lowercase
+      const { res: res3 } = await createTeam(app, cookieHeader, ws.data.id, {
+        identifier: 'eng',
+      })
+      expect(res3.status).toBe(400)
+
+      // Numbers
+      const { res: res4 } = await createTeam(app, cookieHeader, ws.data.id, {
+        identifier: 'AB1',
+      })
+      expect(res4.status).toBe(400)
+    })
+
+    it('should accept valid identifier formats', async () => {
+      const app = createApp()
+      const { cookieHeader } = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const { data: ws } = await createWorkspace(app, cookieHeader)
+
+      // 2 chars (min)
+      const { res: res1 } = await createTeam(app, cookieHeader, ws.data.id, {
+        name: 'Team 1',
+        identifier: 'AB',
+      })
+      expect(res1.status).toBe(201)
+
+      // 5 chars (max)
+      const { res: res2 } = await createTeam(app, cookieHeader, ws.data.id, {
+        name: 'Team 2',
+        identifier: 'ABCDE',
+      })
+      expect(res2.status).toBe(201)
+    })
+
+    it('should return 403 for non-workspace member', async () => {
+      const app = createApp()
+      const owner = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const other = await createAuthenticatedUser(app, {
+        email: 'other@test.com',
+      })
+
+      const { data: ws } = await createWorkspace(app, owner.cookieHeader)
+
+      const { res } = await createTeam(app, other.cookieHeader, ws.data.id, {
+        identifier: 'ENG',
+      })
+
+      expect(res.status).toBe(403)
+    })
+
+    it('should return 403 for member without admin/owner role', async () => {
+      const app = createApp()
+      const owner = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const member = await createAuthenticatedUser(app, {
+        email: 'member@test.com',
+      })
+
+      const { data: ws } = await createWorkspace(app, owner.cookieHeader)
+      const memberUserId = await getUserId(app, member.cookieHeader)
+
+      // Add as regular member
+      await request(
+        app,
+        'POST',
+        `/api/workspaces/${ws.data.id}/members`,
+        owner.cookieHeader,
+        { userId: memberUserId, role: 'member' },
+      )
+
+      const { res } = await createTeam(app, member.cookieHeader, ws.data.id, {
+        identifier: 'ENG',
+      })
+
+      expect(res.status).toBe(403)
+    })
+  })
+
+  describe('GET /api/workspaces/:workspaceId/teams', () => {
+    it('should list teams in workspace', async () => {
+      const app = createApp()
+      const { cookieHeader } = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const { data: ws } = await createWorkspace(app, cookieHeader)
+
+      await createTeam(app, cookieHeader, ws.data.id, {
+        name: 'Engineering',
+        identifier: 'ENG',
+      })
+      await createTeam(app, cookieHeader, ws.data.id, {
+        name: 'Design',
+        identifier: 'DES',
+      })
+
+      const res = await request(
+        app,
+        'GET',
+        `/api/workspaces/${ws.data.id}/teams`,
+        cookieHeader,
+      )
+      const data = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(data.data).toHaveLength(2)
+    })
+  })
+
+  describe('GET /api/workspaces/:workspaceId/teams/:teamId', () => {
+    it('should get team detail', async () => {
+      const app = createApp()
+      const { cookieHeader } = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const { data: ws } = await createWorkspace(app, cookieHeader)
+      const { data: team } = await createTeam(app, cookieHeader, ws.data.id)
+
+      const res = await request(
+        app,
+        'GET',
+        `/api/workspaces/${ws.data.id}/teams/${team.data.id}`,
+        cookieHeader,
+      )
+      const data = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(data.data.id).toBe(team.data.id)
+      expect(data.data.name).toBe('Engineering')
+    })
+
+    it('should return 404 for non-existent team', async () => {
+      const app = createApp()
+      const { cookieHeader } = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const { data: ws } = await createWorkspace(app, cookieHeader)
+
+      const res = await request(
+        app,
+        'GET',
+        `/api/workspaces/${ws.data.id}/teams/nonexistent-id`,
+        cookieHeader,
+      )
+
+      expect(res.status).toBe(404)
+    })
+  })
+
+  describe('PATCH /api/workspaces/:workspaceId/teams/:teamId', () => {
+    it('should update team name', async () => {
+      const app = createApp()
+      const { cookieHeader } = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const { data: ws } = await createWorkspace(app, cookieHeader)
+      const { data: team } = await createTeam(app, cookieHeader, ws.data.id)
+
+      const res = await request(
+        app,
+        'PATCH',
+        `/api/workspaces/${ws.data.id}/teams/${team.data.id}`,
+        cookieHeader,
+        { name: 'Backend Team' },
+      )
+      const data = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(data.data.name).toBe('Backend Team')
+    })
+  })
+
+  describe('DELETE /api/workspaces/:workspaceId/teams/:teamId', () => {
+    it('should delete team', async () => {
+      const app = createApp()
+      const { cookieHeader } = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const { data: ws } = await createWorkspace(app, cookieHeader)
+      const { data: team } = await createTeam(app, cookieHeader, ws.data.id)
+
+      const res = await request(
+        app,
+        'DELETE',
+        `/api/workspaces/${ws.data.id}/teams/${team.data.id}`,
+        cookieHeader,
+      )
+
+      expect(res.status).toBe(200)
+
+      // Verify deleted
+      const listRes = await request(
+        app,
+        'GET',
+        `/api/workspaces/${ws.data.id}/teams`,
+        cookieHeader,
+      )
+      const listData = await listRes.json()
+      expect(listData.data).toHaveLength(0)
+    })
+  })
+
+  describe('POST /api/workspaces/:workspaceId/teams/:teamId/members', () => {
+    it('should add a workspace member to team', async () => {
+      const app = createApp()
+      const owner = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const member = await createAuthenticatedUser(app, {
+        email: 'member@test.com',
+      })
+
+      const { data: ws } = await createWorkspace(app, owner.cookieHeader)
+      const memberUserId = await getUserId(app, member.cookieHeader)
+
+      // Add user to workspace first
+      await request(
+        app,
+        'POST',
+        `/api/workspaces/${ws.data.id}/members`,
+        owner.cookieHeader,
+        { userId: memberUserId, role: 'member' },
+      )
+
+      const { data: team } = await createTeam(
+        app,
+        owner.cookieHeader,
+        ws.data.id,
+      )
+
+      const res = await request(
+        app,
+        'POST',
+        `/api/workspaces/${ws.data.id}/teams/${team.data.id}/members`,
+        owner.cookieHeader,
+        { userId: memberUserId },
+      )
+      const data = await res.json()
+
+      expect(res.status).toBe(201)
+      expect(data.data.teamId).toBe(team.data.id)
+      expect(data.data.userId).toBe(memberUserId)
+    })
+
+    it('should return 403 when adding non-workspace member to team', async () => {
+      const app = createApp()
+      const owner = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const outsider = await createAuthenticatedUser(app, {
+        email: 'outsider@test.com',
+      })
+
+      const { data: ws } = await createWorkspace(app, owner.cookieHeader)
+      const outsiderUserId = await getUserId(app, outsider.cookieHeader)
+
+      const { data: team } = await createTeam(
+        app,
+        owner.cookieHeader,
+        ws.data.id,
+      )
+
+      const res = await request(
+        app,
+        'POST',
+        `/api/workspaces/${ws.data.id}/teams/${team.data.id}/members`,
+        owner.cookieHeader,
+        { userId: outsiderUserId },
+      )
+
+      expect(res.status).toBe(403)
+    })
+
+    it('should return 409 for duplicate team member', async () => {
+      const app = createApp()
+      const owner = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+      })
+      const member = await createAuthenticatedUser(app, {
+        email: 'member@test.com',
+      })
+
+      const { data: ws } = await createWorkspace(app, owner.cookieHeader)
+      const memberUserId = await getUserId(app, member.cookieHeader)
+
+      // Add user to workspace
+      await request(
+        app,
+        'POST',
+        `/api/workspaces/${ws.data.id}/members`,
+        owner.cookieHeader,
+        { userId: memberUserId, role: 'member' },
+      )
+
+      const { data: team } = await createTeam(
+        app,
+        owner.cookieHeader,
+        ws.data.id,
+      )
+
+      // Add to team (first time)
+      await request(
+        app,
+        'POST',
+        `/api/workspaces/${ws.data.id}/teams/${team.data.id}/members`,
+        owner.cookieHeader,
+        { userId: memberUserId },
+      )
+
+      // Try to add again
+      const res = await request(
+        app,
+        'POST',
+        `/api/workspaces/${ws.data.id}/teams/${team.data.id}/members`,
+        owner.cookieHeader,
+        { userId: memberUserId },
+      )
+
+      expect(res.status).toBe(409)
+    })
+  })
+
+  describe('GET /api/workspaces/:workspaceId/teams/:teamId/members', () => {
+    it('should list team members with user info', async () => {
+      const app = createApp()
+      const owner = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+        name: 'Owner',
+      })
+
+      const { data: ws } = await createWorkspace(app, owner.cookieHeader)
+      const { data: team } = await createTeam(
+        app,
+        owner.cookieHeader,
+        ws.data.id,
+      )
+
+      const res = await request(
+        app,
+        'GET',
+        `/api/workspaces/${ws.data.id}/teams/${team.data.id}/members`,
+        owner.cookieHeader,
+      )
+      const data = await res.json()
+
+      expect(res.status).toBe(200)
+      // Creator is auto-added as team member
+      expect(data.data).toHaveLength(1)
+      expect(data.data[0].user).toBeDefined()
+      expect(data.data[0].user.email).toBe('owner@test.com')
+      expect(data.data[0].user.name).toBe('Owner')
+    })
+
+    it('should list multiple team members', async () => {
+      const app = createApp()
+      const owner = await createAuthenticatedUser(app, {
+        email: 'owner@test.com',
+        name: 'Owner',
+      })
+      const member = await createAuthenticatedUser(app, {
+        email: 'member@test.com',
+        name: 'Member',
+      })
+
+      const { data: ws } = await createWorkspace(app, owner.cookieHeader)
+      const memberUserId = await getUserId(app, member.cookieHeader)
+
+      // Add user to workspace
+      await request(
+        app,
+        'POST',
+        `/api/workspaces/${ws.data.id}/members`,
+        owner.cookieHeader,
+        { userId: memberUserId, role: 'member' },
+      )
+
+      const { data: team } = await createTeam(
+        app,
+        owner.cookieHeader,
+        ws.data.id,
+      )
+
+      // Add member to team
+      await request(
+        app,
+        'POST',
+        `/api/workspaces/${ws.data.id}/teams/${team.data.id}/members`,
+        owner.cookieHeader,
+        { userId: memberUserId },
+      )
+
+      const res = await request(
+        app,
+        'GET',
+        `/api/workspaces/${ws.data.id}/teams/${team.data.id}/members`,
+        owner.cookieHeader,
+      )
+      const data = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(data.data).toHaveLength(2)
+    })
+  })
+})

--- a/packages/shared/src/types/team.ts
+++ b/packages/shared/src/types/team.ts
@@ -2,7 +2,16 @@ export interface Team {
   id: string
   name: string
   identifier: string
+  issueCounter: number
   workspaceId: string
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface TeamMember {
+  id: string
+  teamId: string
+  userId: string
   createdAt: Date
   updatedAt: Date
 }


### PR DESCRIPTION
## Summary
- 팀(`team`) 및 팀 멤버(`team_member`) Drizzle 스키마 추가
- 워크스페이스 하위에 팀 CRUD API 구현 (`/api/workspaces/:workspaceId/teams`)
- 팀 멤버 추가/조회 API 구현 (`/api/workspaces/:workspaceId/teams/:teamId/members`)
- identifier 검증 (`/^[A-Z]{2,5}$/`), 중복 시 409, 형식 오류 시 400
- 워크스페이스 비멤버 접근 시 403
- `ConflictError` (409) 에러 클래스 추가
- shared 패키지 `Team`, `TeamMember` 타입 업데이트

Closes #34

## Test plan
- [x] `pnpm --filter api test` — 전체 64개 테스트 통과 (기존 47개 + 팀 17개)
- [x] `pnpm build` — 성공
- [x] ESLint 통과
- [x] 팀 CRUD 전체 흐름 테스트
- [x] identifier 중복 → 409 테스트
- [x] identifier 형식 오류 → 400 테스트
- [x] 워크스페이스 비멤버 → 403 테스트
- [x] 팀 멤버 추가/조회 테스트
- [x] 비워크스페이스 멤버를 팀에 추가 시 403 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)