### PR TITLE
chore: .claude/worktrees gitignore + VSCode 제외 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ dist/
 .env.*.local
 
 # IDE
-.vscode/
 .idea/
 *.swp
 *.swo
@@ -24,6 +23,9 @@ Thumbs.db
 
 # TanStack Router
 .tanstack/
+
+# Claude Code
+.claude/worktrees/
 
 # Logs
 *.log

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.exclude": {
+    "**/.claude/worktrees": true
+  }
+}


### PR DESCRIPTION
## Summary
- `.gitignore`에서 `.vscode/` 제거하여 에디터 설정을 팀 전체가 공유
- `.claude/worktrees/` gitignore 추가로 워크트리가 untracked로 표시되는 문제 해결
- `.vscode/settings.json`에 `files.exclude` 설정으로 VSCode 탐색기에서 worktrees 숨김

## Test plan
- [ ] `git status`에서 `.claude/worktrees/`가 untracked로 표시되지 않음
- [ ] VSCode에서 `.claude/worktrees/` 디렉토리가 탐색기에 보이지 않음
- [ ] `.vscode/settings.json`이 git에 추적됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)