### PR TITLE
fix: Better Auth baseURL 절대 URL 변환 + useWorkflowStates 인자 수정

### DIFF
--- a/apps/web/src/components/issue/IssueDetailPage.tsx
+++ b/apps/web/src/components/issue/IssueDetailPage.tsx
@@ -39,7 +39,7 @@ export function IssueDetailPage({
     isLoading,
     error,
   } = useIssueByIdentifier(workspace.id, team.id, issueIdentifier)
-  const { data: workflowStates } = useWorkflowStates(team.id)
+  const { data: workflowStates } = useWorkflowStates(workspace.id, team.id)
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-64">

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,5 +1,5 @@
 import { createAuthClient } from 'better-auth/react'
 
 export const authClient = createAuthClient({
-  baseURL: '/api',
+  baseURL: `${window.location.origin}/api`,
 })


### PR DESCRIPTION
## Summary

런타임에서 발생하는 두 가지 버그를 수정합니다.

### 1. Better Auth 흰 화면 (BetterAuthError)

- **증상**: 앱 로딩 시 흰 화면, 콘솔에 `BetterAuthError: Invalid base URL: /api`
- **원인 코드**: `apps/web/src/lib/auth.ts`의 `baseURL: '/api'`
- **원인 분석**:
  - better-auth 1.4.19의 `getBaseURL()` → `withPath()` → `assertHasProtocol()` 순서로 호출
  - `assertHasProtocol('/api')` 내부에서 `new URL('/api')`를 실행하는데, 브라우저에서 상대 경로만으로는 `URL` 생성이 불가 → `TypeError` → `BetterAuthError`로 래핑
  - **기존 버그**: 이 문제는 wave PR이 아닌 commit `89017bd` ("Better Auth baseURL을 프록시 경유 상대 경로로 통일") 시점부터 존재. 이전에는 `baseURL: 'http://localhost:3001'` (절대 URL)이었으나, Vite 프록시 도입 시 `/api`로 변경하면서 발생
- **수정**: `baseURL: '/api'` → `` baseURL: `${window.location.origin}/api` ``

### 2. useWorkflowStates 인자 누락

- **증상**: `IssueDetailPage`에서 워크플로 상태 조회 실패
- **원인 PR**: #67 (이슈 상세 UI 구현)
- **원인 코드**: `IssueDetailPage.tsx`에서 `useWorkflowStates(team.id)` — 함수 시그니처 `(workspaceId, teamId)`에 1개 인자만 전달
- **수정**: `useWorkflowStates(team.id)` → `useWorkflowStates(workspace.id, team.id)`

## Test plan

- [x] `pnpm build` 성공
- [ ] 로그인 후 흰 화면 없이 정상 로딩
- [ ] 이슈 상세 페이지에서 워크플로 상태 드롭다운 정상 작동

🤖 Generated with [Claude Code](https://claude.com/claude-code)