### PR TITLE
fix: Better Auth baseURL을 절대 URL로 변환

### DIFF
--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,5 +1,5 @@
 import { createAuthClient } from 'better-auth/react'
 
 export const authClient = createAuthClient({
-  baseURL: '/api',
+  baseURL: `${window.location.origin}/api`,
 })


### PR DESCRIPTION
## Summary

앱 로딩 시 흰 화면 발생 — `BetterAuthError: Invalid base URL: /api` 수정

## 원인 분석

- **원인 코드**: `apps/web/src/lib/auth.ts`의 `baseURL: '/api'`
- **원인 커밋**: `89017bd` — Better Auth baseURL을 `'http://localhost:3001'`에서 `'/api'`로 변경한 시점 (Vite 프록시 도입)
- **발생 원리**: better-auth 1.4.19의 `getBaseURL()` → `withPath()` → `assertHasProtocol()` 호출 체인에서 `new URL('/api')` 실행 → 브라우저에서 상대 경로로는 URL 생성 불가 → `TypeError` → `BetterAuthError`
- **Wave PR과 무관**: `auth.ts`는 wave PR(#64~#69)에서 변경되지 않았으며, better-auth 버전(1.4.19)도 동일. 기존 잠재 버그

## 수정

`baseURL: '/api'` → `` baseURL: `${window.location.origin}/api` ``

## Test plan

- [x] 로그인 페이지 정상 로딩 (흰 화면 없음)
- [x] 로그인/회원가입 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)