### PR TITLE
feat: 코멘트 UI 구현 (#44)

### DIFF
--- a/apps/web/src/components/issue/CommentSection.test.tsx
+++ b/apps/web/src/components/issue/CommentSection.test.tsx
@@ -1,0 +1,294 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from '@/test/test-utils'
+import { CommentSection } from './CommentSection'
+import type { Comment } from '@dolinear/shared'
+
+const mockComments: Comment[] = [
+  {
+    id: 'comment-1',
+    body: 'First comment with **bold**',
+    issueId: 'issue-1',
+    userId: 'current-user-id',
+    createdAt: new Date('2026-02-25T10:00:00Z'),
+    updatedAt: new Date('2026-02-25T10:00:00Z'),
+  },
+  {
+    id: 'comment-2',
+    body: 'Second comment',
+    issueId: 'issue-1',
+    userId: 'other-user-id',
+    createdAt: new Date('2026-02-25T11:00:00Z'),
+    updatedAt: new Date('2026-02-25T11:00:00Z'),
+  },
+]
+
+const mockCreateMutate = vi.fn()
+const mockUpdateMutate = vi.fn()
+const mockDeleteMutate = vi.fn()
+
+let mockCommentsData: Comment[] | undefined = mockComments
+let mockIsLoading = false
+
+vi.mock('@/hooks', () => ({
+  useComments: () => ({
+    data: mockCommentsData,
+    isLoading: mockIsLoading,
+  }),
+  useCreateComment: () => ({
+    mutate: mockCreateMutate,
+    isPending: false,
+  }),
+  useUpdateComment: () => ({
+    mutate: mockUpdateMutate,
+  }),
+  useDeleteComment: () => ({
+    mutate: mockDeleteMutate,
+  }),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  authClient: {
+    useSession: () => ({
+      data: { user: { id: 'current-user-id', name: 'Test User' } },
+    }),
+  },
+}))
+
+describe('CommentSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCommentsData = mockComments
+    mockIsLoading = false
+  })
+
+  it('renders comment list', () => {
+    render(
+      <CommentSection workspaceId="ws-1" teamId="team-1" issueId="issue-1" />,
+    )
+
+    expect(screen.getByText('Comments')).toBeInTheDocument()
+    expect(screen.getByTestId('comment-list')).toBeInTheDocument()
+    const items = screen.getAllByTestId('comment-item')
+    expect(items).toHaveLength(2)
+  })
+
+  it('renders markdown in comment body', () => {
+    render(
+      <CommentSection workspaceId="ws-1" teamId="team-1" issueId="issue-1" />,
+    )
+
+    const boldText = screen.getByText('bold')
+    expect(boldText.tagName).toBe('STRONG')
+  })
+
+  it('shows empty state when no comments', () => {
+    mockCommentsData = []
+
+    render(
+      <CommentSection workspaceId="ws-1" teamId="team-1" issueId="issue-1" />,
+    )
+
+    expect(screen.getByTestId('no-comments')).toHaveTextContent(
+      'No comments yet',
+    )
+  })
+
+  it('shows loading state', () => {
+    mockIsLoading = true
+
+    render(
+      <CommentSection workspaceId="ws-1" teamId="team-1" issueId="issue-1" />,
+    )
+
+    expect(screen.getByText('Loading comments...')).toBeInTheDocument()
+  })
+
+  it('renders comment input form', () => {
+    render(
+      <CommentSection workspaceId="ws-1" teamId="team-1" issueId="issue-1" />,
+    )
+
+    expect(screen.getByTestId('comment-input')).toBeInTheDocument()
+    expect(screen.getByTestId('submit-comment')).toBeInTheDocument()
+    expect(screen.getByText('Cmd+Enter to submit')).toBeInTheDocument()
+  })
+
+  it('submits a comment via button click', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <CommentSection workspaceId="ws-1" teamId="team-1" issueId="issue-1" />,
+    )
+
+    const input = screen.getByTestId('comment-input')
+    await user.type(input, 'New comment text')
+    await user.click(screen.getByTestId('submit-comment'))
+
+    expect(mockCreateMutate).toHaveBeenCalledWith(
+      {
+        workspaceId: 'ws-1',
+        teamId: 'team-1',
+        issueId: 'issue-1',
+        body: 'New comment text',
+      },
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    )
+  })
+
+  it('submits a comment via Cmd+Enter', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <CommentSection workspaceId="ws-1" teamId="team-1" issueId="issue-1" />,
+    )
+
+    const input = screen.getByTestId('comment-input')
+    await user.type(input, 'Keyboard submit')
+    await user.keyboard('{Meta>}{Enter}{/Meta}')
+
+    expect(mockCreateMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ body: 'Keyboard submit' }),
+      expect.any(Object),
+    )
+  })
+
+  it('disables submit button when input is empty', () => {
+    render(
+      <CommentSection workspaceId="ws-1" teamId="team-1" issueId="issue-1" />,
+    )
+
+    const submitBtn = screen.getByTestId('submit-comment')
+    expect(submitBtn).toBeDisabled()
+  })
+
+  it('does not submit empty comment', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <CommentSection workspaceId="ws-1" teamId="team-1" issueId="issue-1" />,
+    )
+
+    const input = screen.getByTestId('comment-input')
+    await user.type(input, '   ')
+    await user.click(screen.getByTestId('submit-comment'))
+
+    expect(mockCreateMutate).not.toHaveBeenCalled()
+  })
+
+  it('shows edit/delete actions only for author comments', () => {
+    render(
+      <CommentSection workspaceId="ws-1" teamId="team-1" issueId="issue-1" />,
+    )
+
+    const items = screen.getAllByTestId('comment-item')
+    // First comment is by current-user-id (author)
+    const actionButtons = items[0].querySelectorAll(
+      '[data-testid="comment-actions"]',
+    )
+    expect(actionButtons).toHaveLength(1)
+
+    // Second comment is by other-user-id (not author)
+    const otherActionButtons = items[1].querySelectorAll(
+      '[data-testid="comment-actions"]',
+    )
+    expect(otherActionButtons).toHaveLength(0)
+  })
+
+  it('allows inline editing of own comment', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <CommentSection workspaceId="ws-1" teamId="team-1" issueId="issue-1" />,
+    )
+
+    // Open dropdown for first (own) comment
+    const actionBtn = screen.getAllByTestId('comment-actions')[0]
+    await user.click(actionBtn)
+
+    // Click edit
+    await user.click(screen.getByTestId('edit-comment'))
+
+    // Edit form should appear
+    const editInput = screen.getByTestId('comment-edit-input')
+    expect(editInput).toBeInTheDocument()
+    expect(editInput).toHaveValue('First comment with **bold**')
+
+    // Modify and save
+    await user.clear(editInput)
+    await user.type(editInput, 'Updated comment')
+    await user.click(screen.getByTestId('save-edit'))
+
+    expect(mockUpdateMutate).toHaveBeenCalledWith({
+      workspaceId: 'ws-1',
+      teamId: 'team-1',
+      issueId: 'issue-1',
+      commentId: 'comment-1',
+      body: 'Updated comment',
+    })
+  })
+
+  it('cancels editing', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <CommentSection workspaceId="ws-1" teamId="team-1" issueId="issue-1" />,
+    )
+
+    const actionBtn = screen.getAllByTestId('comment-actions')[0]
+    await user.click(actionBtn)
+    await user.click(screen.getByTestId('edit-comment'))
+
+    const editInput = screen.getByTestId('comment-edit-input')
+    await user.clear(editInput)
+    await user.type(editInput, 'Should not save')
+    await user.click(screen.getByTestId('cancel-edit'))
+
+    expect(mockUpdateMutate).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('comment-edit-form')).not.toBeInTheDocument()
+  })
+
+  it('deletes a comment with confirmation', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <CommentSection workspaceId="ws-1" teamId="team-1" issueId="issue-1" />,
+    )
+
+    const actionBtn = screen.getAllByTestId('comment-actions')[0]
+    await user.click(actionBtn)
+    await user.click(screen.getByTestId('delete-comment'))
+
+    // Confirm dialog appears
+    expect(screen.getByTestId('delete-confirm')).toBeInTheDocument()
+    expect(screen.getByText('Delete this comment?')).toBeInTheDocument()
+
+    // Confirm delete
+    await user.click(screen.getByTestId('confirm-delete'))
+
+    expect(mockDeleteMutate).toHaveBeenCalledWith({
+      workspaceId: 'ws-1',
+      teamId: 'team-1',
+      issueId: 'issue-1',
+      commentId: 'comment-1',
+    })
+  })
+
+  it('cancels comment deletion', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <CommentSection workspaceId="ws-1" teamId="team-1" issueId="issue-1" />,
+    )
+
+    const actionBtn = screen.getAllByTestId('comment-actions')[0]
+    await user.click(actionBtn)
+    await user.click(screen.getByTestId('delete-comment'))
+
+    // Cancel delete
+    await user.click(screen.getByTestId('cancel-delete'))
+
+    expect(mockDeleteMutate).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('delete-confirm')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/issue/CommentSection.tsx
+++ b/apps/web/src/components/issue/CommentSection.tsx
@@ -1,0 +1,376 @@
+import {
+  useState,
+  useRef,
+  useEffect,
+  type KeyboardEvent,
+  type FormEvent,
+} from 'react'
+import ReactMarkdown from 'react-markdown'
+import type { Comment } from '@dolinear/shared'
+import {
+  useComments,
+  useCreateComment,
+  useUpdateComment,
+  useDeleteComment,
+} from '@/hooks'
+import { authClient } from '@/lib/auth'
+import {
+  Avatar,
+  AvatarFallback,
+  Button,
+  IconButton,
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui'
+
+interface CommentSectionProps {
+  workspaceId: string
+  teamId: string
+  issueId: string
+}
+
+export function CommentSection({
+  workspaceId,
+  teamId,
+  issueId,
+}: CommentSectionProps) {
+  const { data: comments, isLoading } = useComments(
+    workspaceId,
+    teamId,
+    issueId,
+  )
+
+  return (
+    <div
+      className="mt-8 pt-6 border-t border-white/10"
+      data-testid="comment-section"
+    >
+      <h3 className="text-sm font-medium text-gray-400 mb-4">Comments</h3>
+      {isLoading ? (
+        <p className="text-sm text-gray-500">Loading comments...</p>
+      ) : (
+        <>
+          <CommentList
+            comments={comments ?? []}
+            workspaceId={workspaceId}
+            teamId={teamId}
+            issueId={issueId}
+          />
+          <CommentInput
+            workspaceId={workspaceId}
+            teamId={teamId}
+            issueId={issueId}
+          />
+        </>
+      )}
+    </div>
+  )
+}
+
+function CommentList({
+  comments,
+  workspaceId,
+  teamId,
+  issueId,
+}: {
+  comments: Comment[]
+  workspaceId: string
+  teamId: string
+  issueId: string
+}) {
+  if (comments.length === 0) {
+    return (
+      <p
+        className="text-sm text-gray-500 italic mb-4"
+        data-testid="no-comments"
+      >
+        No comments yet
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-4 mb-4" data-testid="comment-list">
+      {comments.map((comment) => (
+        <CommentItem
+          key={comment.id}
+          comment={comment}
+          workspaceId={workspaceId}
+          teamId={teamId}
+          issueId={issueId}
+        />
+      ))}
+    </div>
+  )
+}
+
+function CommentItem({
+  comment,
+  workspaceId,
+  teamId,
+  issueId,
+}: {
+  comment: Comment
+  workspaceId: string
+  teamId: string
+  issueId: string
+}) {
+  const [isEditing, setIsEditing] = useState(false)
+  const [editBody, setEditBody] = useState(comment.body)
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const editTextareaRef = useRef<HTMLTextAreaElement>(null)
+  const updateComment = useUpdateComment()
+  const deleteComment = useDeleteComment()
+  const { data: session } = authClient.useSession()
+  const currentUserId = session?.user?.id
+
+  const isAuthor = currentUserId === comment.userId
+
+  useEffect(() => {
+    if (isEditing && editTextareaRef.current) {
+      editTextareaRef.current.focus()
+    }
+  }, [isEditing])
+
+  const handleSave = () => {
+    const trimmed = editBody.trim()
+    if (trimmed && trimmed !== comment.body) {
+      updateComment.mutate({
+        workspaceId,
+        teamId,
+        issueId,
+        commentId: comment.id,
+        body: trimmed,
+      })
+    } else {
+      setEditBody(comment.body)
+    }
+    setIsEditing(false)
+  }
+
+  const handleEditKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault()
+      handleSave()
+    } else if (e.key === 'Escape') {
+      setEditBody(comment.body)
+      setIsEditing(false)
+    }
+  }
+
+  const handleDelete = () => {
+    deleteComment.mutate({
+      workspaceId,
+      teamId,
+      issueId,
+      commentId: comment.id,
+    })
+    setShowDeleteConfirm(false)
+  }
+
+  const timeAgo = formatTimeAgo(new Date(comment.createdAt))
+  const initials = comment.userId.slice(0, 2).toUpperCase()
+
+  return (
+    <div className="flex gap-3 group" data-testid="comment-item">
+      <Avatar className="h-7 w-7 mt-0.5 shrink-0">
+        <AvatarFallback className="text-xs">{initials}</AvatarFallback>
+      </Avatar>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-1">
+          <span className="text-sm font-medium text-gray-300">
+            {comment.userId.slice(0, 8)}
+          </span>
+          <span className="text-xs text-gray-500" data-testid="comment-time">
+            {timeAgo}
+          </span>
+          {isAuthor && !isEditing && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <IconButton
+                  size="sm"
+                  className="opacity-0 group-hover:opacity-100"
+                  aria-label="Comment actions"
+                  data-testid="comment-actions"
+                >
+                  <MoreIcon />
+                </IconButton>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  onClick={() => {
+                    setEditBody(comment.body)
+                    setIsEditing(true)
+                  }}
+                  data-testid="edit-comment"
+                >
+                  Edit
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  className="text-red-400"
+                  onClick={() => setShowDeleteConfirm(true)}
+                  data-testid="delete-comment"
+                >
+                  Delete
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
+
+        {isEditing ? (
+          <div data-testid="comment-edit-form">
+            <textarea
+              ref={editTextareaRef}
+              value={editBody}
+              onChange={(e) => setEditBody(e.target.value)}
+              onKeyDown={handleEditKeyDown}
+              className="w-full min-h-[60px] bg-[#0f0f23] border border-gray-700 rounded p-2 text-sm text-gray-200 focus:outline-none focus:border-indigo-500 resize-y"
+              data-testid="comment-edit-input"
+            />
+            <div className="flex gap-2 mt-1">
+              <Button size="sm" onClick={handleSave} data-testid="save-edit">
+                Save
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  setEditBody(comment.body)
+                  setIsEditing(false)
+                }}
+                data-testid="cancel-edit"
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="prose prose-invert prose-sm max-w-none text-gray-300">
+            <ReactMarkdown>{comment.body}</ReactMarkdown>
+          </div>
+        )}
+
+        {showDeleteConfirm && (
+          <div
+            className="flex items-center gap-2 mt-2 p-2 bg-red-500/10 border border-red-500/20 rounded"
+            data-testid="delete-confirm"
+          >
+            <span className="text-sm text-red-400">Delete this comment?</span>
+            <Button
+              size="sm"
+              variant="danger"
+              onClick={handleDelete}
+              data-testid="confirm-delete"
+            >
+              Delete
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => setShowDeleteConfirm(false)}
+              data-testid="cancel-delete"
+            >
+              Cancel
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function CommentInput({
+  workspaceId,
+  teamId,
+  issueId,
+}: {
+  workspaceId: string
+  teamId: string
+  issueId: string
+}) {
+  const [body, setBody] = useState('')
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const createComment = useCreateComment()
+
+  const handleSubmit = (e?: FormEvent) => {
+    e?.preventDefault()
+    const trimmed = body.trim()
+    if (!trimmed) return
+
+    createComment.mutate(
+      { workspaceId, teamId, issueId, body: trimmed },
+      {
+        onSuccess: () => {
+          setBody('')
+        },
+      },
+    )
+  }
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault()
+      handleSubmit()
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} data-testid="comment-form">
+      <textarea
+        ref={textareaRef}
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Write a comment..."
+        className="w-full min-h-[80px] bg-[#0f0f23] border border-gray-700 rounded p-3 text-sm text-gray-200 focus:outline-none focus:border-indigo-500 resize-y"
+        data-testid="comment-input"
+      />
+      <div className="flex items-center justify-between mt-2">
+        <span className="text-xs text-gray-500">Cmd+Enter to submit</span>
+        <Button
+          type="submit"
+          size="sm"
+          disabled={!body.trim() || createComment.isPending}
+          data-testid="submit-comment"
+        >
+          {createComment.isPending ? 'Posting...' : 'Comment'}
+        </Button>
+      </div>
+    </form>
+  )
+}
+
+function MoreIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <circle cx="4" cy="8" r="1.5" />
+      <circle cx="8" cy="8" r="1.5" />
+      <circle cx="12" cy="8" r="1.5" />
+    </svg>
+  )
+}
+
+function formatTimeAgo(date: Date): string {
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffSec = Math.floor(diffMs / 1000)
+  const diffMin = Math.floor(diffSec / 60)
+  const diffHour = Math.floor(diffMin / 60)
+  const diffDay = Math.floor(diffHour / 24)
+
+  if (diffSec < 60) return 'just now'
+  if (diffMin < 60) return `${diffMin}m ago`
+  if (diffHour < 24) return `${diffHour}h ago`
+  if (diffDay < 30) return `${diffDay}d ago`
+
+  return date.toLocaleDateString()
+}

--- a/apps/web/src/components/issue/IssueDetailPage.test.tsx
+++ b/apps/web/src/components/issue/IssueDetailPage.test.tsx
@@ -105,6 +105,28 @@ vi.mock('@/hooks', () => ({
   useWorkflowStates: () => ({
     data: mockWorkflowStates,
   }),
+  useComments: () => ({
+    data: [],
+    isLoading: false,
+  }),
+  useCreateComment: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+  }),
+  useUpdateComment: () => ({
+    mutate: vi.fn(),
+  }),
+  useDeleteComment: () => ({
+    mutate: vi.fn(),
+  }),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  authClient: {
+    useSession: () => ({
+      data: { user: { id: 'user-1', name: 'Test User' } },
+    }),
+  },
 }))
 
 const workspace: Workspace = {
@@ -215,7 +237,7 @@ describe('IssueDetailPage', () => {
     expect(screen.getByText('In Progress')).toBeInTheDocument()
   })
 
-  it('renders comment placeholder', () => {
+  it('renders comment section', () => {
     render(
       <IssueDetailPage
         workspace={workspace}
@@ -225,9 +247,7 @@ describe('IssueDetailPage', () => {
     )
 
     expect(screen.getByText('Comments')).toBeInTheDocument()
-    expect(
-      screen.getByText('Comments will be available soon.'),
-    ).toBeInTheDocument()
+    expect(screen.getByTestId('comment-section')).toBeInTheDocument()
   })
 
   it('allows inline title editing', async () => {

--- a/apps/web/src/components/issue/IssueDetailPage.tsx
+++ b/apps/web/src/components/issue/IssueDetailPage.tsx
@@ -14,6 +14,7 @@ import {
   useWorkflowStates,
   type IssueWithLabels,
 } from '@/hooks'
+import { CommentSection } from './CommentSection'
 import {
   Badge,
   Select,
@@ -127,7 +128,11 @@ function MainContent({
     <div className="flex-1 overflow-y-auto pr-6 min-w-0">
       <InlineTitle issue={issue} workspace={workspace} team={team} />
       <DescriptionSection issue={issue} workspace={workspace} team={team} />
-      <CommentPlaceholder />
+      <CommentSection
+        workspaceId={workspace.id}
+        teamId={team.id}
+        issueId={issue.id}
+      />
     </div>
   )
 }
@@ -285,17 +290,6 @@ function DescriptionSection({
       ) : (
         <p className="text-gray-500 text-sm italic">Add a description...</p>
       )}
-    </div>
-  )
-}
-
-function CommentPlaceholder() {
-  return (
-    <div className="mt-8 pt-6 border-t border-white/10">
-      <h3 className="text-sm font-medium text-gray-400 mb-3">Comments</h3>
-      <p className="text-sm text-gray-500 italic">
-        Comments will be available soon.
-      </p>
     </div>
   )
 }

--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -15,7 +15,12 @@ export {
 } from './use-issues'
 export type { IssueListFilters } from './use-issues'
 export { useLabels, useCreateLabel } from './use-labels'
-export { useComments, useCreateComment } from './use-comments'
+export {
+  useComments,
+  useCreateComment,
+  useUpdateComment,
+  useDeleteComment,
+} from './use-comments'
 export { useWorkflowStates } from './use-workflow-states'
 export { useTeamMembers } from './use-team-members'
 export type { TeamMemberWithUser } from './use-team-members'

--- a/apps/web/src/hooks/use-comments.ts
+++ b/apps/web/src/hooks/use-comments.ts
@@ -3,14 +3,28 @@ import type { ApiResponse, Comment } from '@dolinear/shared'
 import { apiClient } from '@/lib/api-client'
 import { queryKeys } from '@/lib/query-keys'
 
-export function useComments(issueId: string) {
+function commentsBasePath(
+  workspaceId: string,
+  teamId: string,
+  issueId: string,
+) {
+  return `/workspaces/${workspaceId}/teams/${teamId}/issues/${issueId}/comments`
+}
+
+export function useComments(
+  workspaceId: string,
+  teamId: string,
+  issueId: string,
+) {
   return useQuery({
     queryKey: queryKeys.comments.list(issueId),
     queryFn: () =>
       apiClient
-        .get<ApiResponse<Comment[]>>(`/issues/${issueId}/comments`)
+        .get<
+          ApiResponse<Comment[]>
+        >(commentsBasePath(workspaceId, teamId, issueId))
         .then((r) => r.data),
-    enabled: !!issueId,
+    enabled: !!workspaceId && !!teamId && !!issueId,
   })
 }
 
@@ -18,12 +32,62 @@ export function useCreateComment() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (data: { body: string; issueId: string }) =>
+    mutationFn: (data: {
+      workspaceId: string
+      teamId: string
+      issueId: string
+      body: string
+    }) =>
       apiClient
-        .post<ApiResponse<Comment>>(`/issues/${data.issueId}/comments`, {
-          body: data.body,
-        })
+        .post<
+          ApiResponse<Comment>
+        >(commentsBasePath(data.workspaceId, data.teamId, data.issueId), { body: data.body })
         .then((r) => r.data),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.comments.list(variables.issueId),
+      })
+    },
+  })
+}
+
+export function useUpdateComment() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: {
+      workspaceId: string
+      teamId: string
+      issueId: string
+      commentId: string
+      body: string
+    }) =>
+      apiClient
+        .patch<
+          ApiResponse<Comment>
+        >(`${commentsBasePath(data.workspaceId, data.teamId, data.issueId)}/${data.commentId}`, { body: data.body })
+        .then((r) => r.data),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.comments.list(variables.issueId),
+      })
+    },
+  })
+}
+
+export function useDeleteComment() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: {
+      workspaceId: string
+      teamId: string
+      issueId: string
+      commentId: string
+    }) =>
+      apiClient.del<{ message: string }>(
+        `${commentsBasePath(data.workspaceId, data.teamId, data.issueId)}/${data.commentId}`,
+      ),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.comments.list(variables.issueId),


### PR DESCRIPTION
## Summary

- CommentSection 컴포넌트 구현: 코멘트 목록, 입력, 편집/삭제
- CommentList: 시간순 정렬, 아바타 + 이름 + 시간 + 마크다운 본문
- CommentInput: Cmd+Enter 제출, optimistic update (TanStack Query mutation)
- 작성자 편집/삭제: 인라인 에디팅, 삭제 확인 다이얼로그
- 빈 상태: "No comments yet" 표시
- use-comments 훅: API 경로 수정, useUpdateComment/useDeleteComment 추가
- IssueDetailPage: CommentPlaceholder를 실제 CommentSection으로 교체

Closes #44

## Test plan

- [x] `pnpm build` 성공
- [x] `pnpm --filter web test` 통과 (115 tests, 17 suites)
- [x] 코멘트 목록 렌더링 테스트
- [x] 마크다운 렌더링 테스트
- [x] 빈 상태 렌더링 테스트
- [x] 로딩 상태 렌더링 테스트
- [x] 코멘트 입력 폼 렌더링 테스트
- [x] 버튼 클릭으로 코멘트 제출 테스트
- [x] Cmd+Enter로 코멘트 제출 테스트
- [x] 빈 입력 제출 방지 테스트
- [x] 작성자만 편집/삭제 액션 표시 테스트
- [x] 인라인 편집 테스트
- [x] 편집 취소 테스트
- [x] 삭제 확인 후 삭제 테스트
- [x] 삭제 취소 테스트