### PR TITLE
feat: 워크스페이스 설정 페이지 + 멤버 관리 UI

### DIFF
--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -99,13 +99,13 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
             </li>
             <li>
               <Link
-                to="/workspace/$workspaceSlug/settings/teams"
+                to="/workspace/$workspaceSlug/settings/general"
                 params={{ workspaceSlug: currentSlug }}
-                data-testid="sidebar-teams-settings"
+                data-testid="sidebar-settings"
                 className="flex items-center rounded px-3 py-1.5 text-sm text-gray-500 hover:bg-white/5 hover:text-gray-300"
                 activeProps={{ className: 'bg-white/10 text-white' }}
               >
-                Teams settings
+                Settings
               </Link>
             </li>
           </ul>

--- a/apps/web/src/hooks/use-workspace-members.ts
+++ b/apps/web/src/hooks/use-workspace-members.ts
@@ -1,0 +1,48 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import type {
+  ApiResponse,
+  WorkspaceMember,
+  WorkspaceMemberRole,
+  User,
+} from '@dolinear/shared'
+import { apiClient } from '@/lib/api-client'
+import { queryKeys } from '@/lib/query-keys'
+
+export interface WorkspaceMemberWithUser extends WorkspaceMember {
+  user: Pick<User, 'id' | 'name' | 'email' | 'image'>
+}
+
+export function useWorkspaceMembers(workspaceId: string) {
+  return useQuery({
+    queryKey: queryKeys.workspaceMembers.list(workspaceId),
+    queryFn: () =>
+      apiClient
+        .get<
+          ApiResponse<WorkspaceMemberWithUser[]>
+        >(`/workspaces/${workspaceId}/members`)
+        .then((r) => r.data),
+    enabled: !!workspaceId,
+  })
+}
+
+export function useAddWorkspaceMember() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: {
+      workspaceId: string
+      userId: string
+      role: WorkspaceMemberRole
+    }) =>
+      apiClient
+        .post<
+          ApiResponse<WorkspaceMember>
+        >(`/workspaces/${data.workspaceId}/members`, { userId: data.userId, role: data.role })
+        .then((r) => r.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.workspaceMembers.all,
+      })
+    },
+  })
+}

--- a/apps/web/src/hooks/use-workspaces.ts
+++ b/apps/web/src/hooks/use-workspaces.ts
@@ -37,3 +37,19 @@ export function useCreateWorkspace() {
     },
   })
 }
+
+export function useUpdateWorkspace() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: { workspaceId: string; name: string }) =>
+      apiClient
+        .patch<ApiResponse<Workspace>>(`/workspaces/${data.workspaceId}`, {
+          name: data.name,
+        })
+        .then((r) => r.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.workspaces.all })
+    },
+  })
+}

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -34,4 +34,9 @@ export const queryKeys = {
     all: ['teamMembers'] as const,
     list: (teamId: string) => ['teamMembers', 'list', teamId] as const,
   },
+  workspaceMembers: {
+    all: ['workspaceMembers'] as const,
+    list: (workspaceId: string) =>
+      ['workspaceMembers', 'list', workspaceId] as const,
+  },
 }

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -16,9 +16,14 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as AuthenticatedDashboardRouteImport } from './routes/_authenticated/dashboard'
 import { Route as AuthenticatedWorkspaceWorkspaceSlugRouteImport } from './routes/_authenticated/workspace/$workspaceSlug'
 import { Route as AuthenticatedWorkspaceWorkspaceSlugIndexRouteImport } from './routes/_authenticated/workspace/$workspaceSlug/index'
+import { Route as AuthenticatedWorkspaceWorkspaceSlugSettingsRouteImport } from './routes/_authenticated/workspace/$workspaceSlug/settings'
+import { Route as AuthenticatedWorkspaceWorkspaceSlugSettingsIndexRouteImport } from './routes/_authenticated/workspace/$workspaceSlug/settings/index'
 import { Route as AuthenticatedWorkspaceWorkspaceSlugMyIssuesIndexRouteImport } from './routes/_authenticated/workspace/$workspaceSlug/my-issues/index'
 import { Route as AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierRouteImport } from './routes/_authenticated/workspace/$workspaceSlug/team/$teamIdentifier'
 import { Route as AuthenticatedWorkspaceWorkspaceSlugSettingsTeamsRouteImport } from './routes/_authenticated/workspace/$workspaceSlug/settings/teams'
+import { Route as AuthenticatedWorkspaceWorkspaceSlugSettingsMembersRouteImport } from './routes/_authenticated/workspace/$workspaceSlug/settings/members'
+import { Route as AuthenticatedWorkspaceWorkspaceSlugSettingsLabelsRouteImport } from './routes/_authenticated/workspace/$workspaceSlug/settings/labels'
+import { Route as AuthenticatedWorkspaceWorkspaceSlugSettingsGeneralRouteImport } from './routes/_authenticated/workspace/$workspaceSlug/settings/general'
 import { Route as AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierIssuesIndexRouteImport } from './routes/_authenticated/workspace/$workspaceSlug/team/$teamIdentifier/issues/index'
 import { Route as AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierBacklogIndexRouteImport } from './routes/_authenticated/workspace/$workspaceSlug/team/$teamIdentifier/backlog/index'
 import { Route as AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierActiveIndexRouteImport } from './routes/_authenticated/workspace/$workspaceSlug/team/$teamIdentifier/active/index'
@@ -61,6 +66,18 @@ const AuthenticatedWorkspaceWorkspaceSlugIndexRoute =
     path: '/',
     getParentRoute: () => AuthenticatedWorkspaceWorkspaceSlugRoute,
   } as any)
+const AuthenticatedWorkspaceWorkspaceSlugSettingsRoute =
+  AuthenticatedWorkspaceWorkspaceSlugSettingsRouteImport.update({
+    id: '/settings',
+    path: '/settings',
+    getParentRoute: () => AuthenticatedWorkspaceWorkspaceSlugRoute,
+  } as any)
+const AuthenticatedWorkspaceWorkspaceSlugSettingsIndexRoute =
+  AuthenticatedWorkspaceWorkspaceSlugSettingsIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedWorkspaceWorkspaceSlugSettingsRoute,
+  } as any)
 const AuthenticatedWorkspaceWorkspaceSlugMyIssuesIndexRoute =
   AuthenticatedWorkspaceWorkspaceSlugMyIssuesIndexRouteImport.update({
     id: '/my-issues/',
@@ -75,9 +92,27 @@ const AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierRoute =
   } as any)
 const AuthenticatedWorkspaceWorkspaceSlugSettingsTeamsRoute =
   AuthenticatedWorkspaceWorkspaceSlugSettingsTeamsRouteImport.update({
-    id: '/settings/teams',
-    path: '/settings/teams',
-    getParentRoute: () => AuthenticatedWorkspaceWorkspaceSlugRoute,
+    id: '/teams',
+    path: '/teams',
+    getParentRoute: () => AuthenticatedWorkspaceWorkspaceSlugSettingsRoute,
+  } as any)
+const AuthenticatedWorkspaceWorkspaceSlugSettingsMembersRoute =
+  AuthenticatedWorkspaceWorkspaceSlugSettingsMembersRouteImport.update({
+    id: '/members',
+    path: '/members',
+    getParentRoute: () => AuthenticatedWorkspaceWorkspaceSlugSettingsRoute,
+  } as any)
+const AuthenticatedWorkspaceWorkspaceSlugSettingsLabelsRoute =
+  AuthenticatedWorkspaceWorkspaceSlugSettingsLabelsRouteImport.update({
+    id: '/labels',
+    path: '/labels',
+    getParentRoute: () => AuthenticatedWorkspaceWorkspaceSlugSettingsRoute,
+  } as any)
+const AuthenticatedWorkspaceWorkspaceSlugSettingsGeneralRoute =
+  AuthenticatedWorkspaceWorkspaceSlugSettingsGeneralRouteImport.update({
+    id: '/general',
+    path: '/general',
+    getParentRoute: () => AuthenticatedWorkspaceWorkspaceSlugSettingsRoute,
   } as any)
 const AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierIssuesIndexRoute =
   AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierIssuesIndexRouteImport.update(
@@ -131,10 +166,15 @@ export interface FileRoutesByFullPath {
   '/signup': typeof SignupRoute
   '/dashboard': typeof AuthenticatedDashboardRoute
   '/workspace/$workspaceSlug': typeof AuthenticatedWorkspaceWorkspaceSlugRouteWithChildren
+  '/workspace/$workspaceSlug/settings': typeof AuthenticatedWorkspaceWorkspaceSlugSettingsRouteWithChildren
   '/workspace/$workspaceSlug/': typeof AuthenticatedWorkspaceWorkspaceSlugIndexRoute
+  '/workspace/$workspaceSlug/settings/general': typeof AuthenticatedWorkspaceWorkspaceSlugSettingsGeneralRoute
+  '/workspace/$workspaceSlug/settings/labels': typeof AuthenticatedWorkspaceWorkspaceSlugSettingsLabelsRoute
+  '/workspace/$workspaceSlug/settings/members': typeof AuthenticatedWorkspaceWorkspaceSlugSettingsMembersRoute
   '/workspace/$workspaceSlug/settings/teams': typeof AuthenticatedWorkspaceWorkspaceSlugSettingsTeamsRoute
   '/workspace/$workspaceSlug/team/$teamIdentifier': typeof AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierRouteWithChildren
   '/workspace/$workspaceSlug/my-issues/': typeof AuthenticatedWorkspaceWorkspaceSlugMyIssuesIndexRoute
+  '/workspace/$workspaceSlug/settings/': typeof AuthenticatedWorkspaceWorkspaceSlugSettingsIndexRoute
   '/workspace/$workspaceSlug/team/$teamIdentifier/issue/$issueIdentifier': typeof AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierIssueIssueIdentifierRoute
   '/workspace/$workspaceSlug/team/$teamIdentifier/issues/$issueIdentifier': typeof AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierIssuesIssueIdentifierRoute
   '/workspace/$workspaceSlug/team/$teamIdentifier/active/': typeof AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierActiveIndexRoute
@@ -147,9 +187,13 @@ export interface FileRoutesByTo {
   '/signup': typeof SignupRoute
   '/dashboard': typeof AuthenticatedDashboardRoute
   '/workspace/$workspaceSlug': typeof AuthenticatedWorkspaceWorkspaceSlugIndexRoute
+  '/workspace/$workspaceSlug/settings/general': typeof AuthenticatedWorkspaceWorkspaceSlugSettingsGeneralRoute
+  '/workspace/$workspaceSlug/settings/labels': typeof AuthenticatedWorkspaceWorkspaceSlugSettingsLabelsRoute
+  '/workspace/$workspaceSlug/settings/members': typeof AuthenticatedWorkspaceWorkspaceSlugSettingsMembersRoute
   '/workspace/$workspaceSlug/settings/teams': typeof AuthenticatedWorkspaceWorkspaceSlugSettingsTeamsRoute
   '/workspace/$workspaceSlug/team/$teamIdentifier': typeof AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierRouteWithChildren
   '/workspace/$workspaceSlug/my-issues': typeof AuthenticatedWorkspaceWorkspaceSlugMyIssuesIndexRoute
+  '/workspace/$workspaceSlug/settings': typeof AuthenticatedWorkspaceWorkspaceSlugSettingsIndexRoute
   '/workspace/$workspaceSlug/team/$teamIdentifier/issue/$issueIdentifier': typeof AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierIssueIssueIdentifierRoute
   '/workspace/$workspaceSlug/team/$teamIdentifier/issues/$issueIdentifier': typeof AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierIssuesIssueIdentifierRoute
   '/workspace/$workspaceSlug/team/$teamIdentifier/active': typeof AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierActiveIndexRoute
@@ -164,10 +208,15 @@ export interface FileRoutesById {
   '/signup': typeof SignupRoute
   '/_authenticated/dashboard': typeof AuthenticatedDashboardRoute
   '/_authenticated/workspace/$workspaceSlug': typeof AuthenticatedWorkspaceWorkspaceSlugRouteWithChildren
+  '/_authenticated/workspace/$workspaceSlug/settings': typeof AuthenticatedWorkspaceWorkspaceSlugSettingsRouteWithChildren
   '/_authenticated/workspace/$workspaceSlug/': typeof AuthenticatedWorkspaceWorkspaceSlugIndexRoute
+  '/_authenticated/workspace/$workspaceSlug/settings/general': typeof AuthenticatedWorkspaceWorkspaceSlugSettingsGeneralRoute
+  '/_authenticated/workspace/$workspaceSlug/settings/labels': typeof AuthenticatedWorkspaceWorkspaceSlugSettingsLabelsRoute
+  '/_authenticated/workspace/$workspaceSlug/settings/members': typeof AuthenticatedWorkspaceWorkspaceSlugSettingsMembersRoute
   '/_authenticated/workspace/$workspaceSlug/settings/teams': typeof AuthenticatedWorkspaceWorkspaceSlugSettingsTeamsRoute
   '/_authenticated/workspace/$workspaceSlug/team/$teamIdentifier': typeof AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierRouteWithChildren
   '/_authenticated/workspace/$workspaceSlug/my-issues/': typeof AuthenticatedWorkspaceWorkspaceSlugMyIssuesIndexRoute
+  '/_authenticated/workspace/$workspaceSlug/settings/': typeof AuthenticatedWorkspaceWorkspaceSlugSettingsIndexRoute
   '/_authenticated/workspace/$workspaceSlug/team/$teamIdentifier/issue/$issueIdentifier': typeof AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierIssueIssueIdentifierRoute
   '/_authenticated/workspace/$workspaceSlug/team/$teamIdentifier/issues/$issueIdentifier': typeof AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierIssuesIssueIdentifierRoute
   '/_authenticated/workspace/$workspaceSlug/team/$teamIdentifier/active/': typeof AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierActiveIndexRoute
@@ -182,10 +231,15 @@ export interface FileRouteTypes {
     | '/signup'
     | '/dashboard'
     | '/workspace/$workspaceSlug'
+    | '/workspace/$workspaceSlug/settings'
     | '/workspace/$workspaceSlug/'
+    | '/workspace/$workspaceSlug/settings/general'
+    | '/workspace/$workspaceSlug/settings/labels'
+    | '/workspace/$workspaceSlug/settings/members'
     | '/workspace/$workspaceSlug/settings/teams'
     | '/workspace/$workspaceSlug/team/$teamIdentifier'
     | '/workspace/$workspaceSlug/my-issues/'
+    | '/workspace/$workspaceSlug/settings/'
     | '/workspace/$workspaceSlug/team/$teamIdentifier/issue/$issueIdentifier'
     | '/workspace/$workspaceSlug/team/$teamIdentifier/issues/$issueIdentifier'
     | '/workspace/$workspaceSlug/team/$teamIdentifier/active/'
@@ -198,9 +252,13 @@ export interface FileRouteTypes {
     | '/signup'
     | '/dashboard'
     | '/workspace/$workspaceSlug'
+    | '/workspace/$workspaceSlug/settings/general'
+    | '/workspace/$workspaceSlug/settings/labels'
+    | '/workspace/$workspaceSlug/settings/members'
     | '/workspace/$workspaceSlug/settings/teams'
     | '/workspace/$workspaceSlug/team/$teamIdentifier'
     | '/workspace/$workspaceSlug/my-issues'
+    | '/workspace/$workspaceSlug/settings'
     | '/workspace/$workspaceSlug/team/$teamIdentifier/issue/$issueIdentifier'
     | '/workspace/$workspaceSlug/team/$teamIdentifier/issues/$issueIdentifier'
     | '/workspace/$workspaceSlug/team/$teamIdentifier/active'
@@ -214,10 +272,15 @@ export interface FileRouteTypes {
     | '/signup'
     | '/_authenticated/dashboard'
     | '/_authenticated/workspace/$workspaceSlug'
+    | '/_authenticated/workspace/$workspaceSlug/settings'
     | '/_authenticated/workspace/$workspaceSlug/'
+    | '/_authenticated/workspace/$workspaceSlug/settings/general'
+    | '/_authenticated/workspace/$workspaceSlug/settings/labels'
+    | '/_authenticated/workspace/$workspaceSlug/settings/members'
     | '/_authenticated/workspace/$workspaceSlug/settings/teams'
     | '/_authenticated/workspace/$workspaceSlug/team/$teamIdentifier'
     | '/_authenticated/workspace/$workspaceSlug/my-issues/'
+    | '/_authenticated/workspace/$workspaceSlug/settings/'
     | '/_authenticated/workspace/$workspaceSlug/team/$teamIdentifier/issue/$issueIdentifier'
     | '/_authenticated/workspace/$workspaceSlug/team/$teamIdentifier/issues/$issueIdentifier'
     | '/_authenticated/workspace/$workspaceSlug/team/$teamIdentifier/active/'
@@ -283,6 +346,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedWorkspaceWorkspaceSlugIndexRouteImport
       parentRoute: typeof AuthenticatedWorkspaceWorkspaceSlugRoute
     }
+    '/_authenticated/workspace/$workspaceSlug/settings': {
+      id: '/_authenticated/workspace/$workspaceSlug/settings'
+      path: '/settings'
+      fullPath: '/workspace/$workspaceSlug/settings'
+      preLoaderRoute: typeof AuthenticatedWorkspaceWorkspaceSlugSettingsRouteImport
+      parentRoute: typeof AuthenticatedWorkspaceWorkspaceSlugRoute
+    }
+    '/_authenticated/workspace/$workspaceSlug/settings/': {
+      id: '/_authenticated/workspace/$workspaceSlug/settings/'
+      path: '/'
+      fullPath: '/workspace/$workspaceSlug/settings/'
+      preLoaderRoute: typeof AuthenticatedWorkspaceWorkspaceSlugSettingsIndexRouteImport
+      parentRoute: typeof AuthenticatedWorkspaceWorkspaceSlugSettingsRoute
+    }
     '/_authenticated/workspace/$workspaceSlug/my-issues/': {
       id: '/_authenticated/workspace/$workspaceSlug/my-issues/'
       path: '/my-issues'
@@ -299,10 +376,31 @@ declare module '@tanstack/react-router' {
     }
     '/_authenticated/workspace/$workspaceSlug/settings/teams': {
       id: '/_authenticated/workspace/$workspaceSlug/settings/teams'
-      path: '/settings/teams'
+      path: '/teams'
       fullPath: '/workspace/$workspaceSlug/settings/teams'
       preLoaderRoute: typeof AuthenticatedWorkspaceWorkspaceSlugSettingsTeamsRouteImport
-      parentRoute: typeof AuthenticatedWorkspaceWorkspaceSlugRoute
+      parentRoute: typeof AuthenticatedWorkspaceWorkspaceSlugSettingsRoute
+    }
+    '/_authenticated/workspace/$workspaceSlug/settings/members': {
+      id: '/_authenticated/workspace/$workspaceSlug/settings/members'
+      path: '/members'
+      fullPath: '/workspace/$workspaceSlug/settings/members'
+      preLoaderRoute: typeof AuthenticatedWorkspaceWorkspaceSlugSettingsMembersRouteImport
+      parentRoute: typeof AuthenticatedWorkspaceWorkspaceSlugSettingsRoute
+    }
+    '/_authenticated/workspace/$workspaceSlug/settings/labels': {
+      id: '/_authenticated/workspace/$workspaceSlug/settings/labels'
+      path: '/labels'
+      fullPath: '/workspace/$workspaceSlug/settings/labels'
+      preLoaderRoute: typeof AuthenticatedWorkspaceWorkspaceSlugSettingsLabelsRouteImport
+      parentRoute: typeof AuthenticatedWorkspaceWorkspaceSlugSettingsRoute
+    }
+    '/_authenticated/workspace/$workspaceSlug/settings/general': {
+      id: '/_authenticated/workspace/$workspaceSlug/settings/general'
+      path: '/general'
+      fullPath: '/workspace/$workspaceSlug/settings/general'
+      preLoaderRoute: typeof AuthenticatedWorkspaceWorkspaceSlugSettingsGeneralRouteImport
+      parentRoute: typeof AuthenticatedWorkspaceWorkspaceSlugSettingsRoute
     }
     '/_authenticated/workspace/$workspaceSlug/team/$teamIdentifier/issues/': {
       id: '/_authenticated/workspace/$workspaceSlug/team/$teamIdentifier/issues/'
@@ -342,6 +440,33 @@ declare module '@tanstack/react-router' {
   }
 }
 
+interface AuthenticatedWorkspaceWorkspaceSlugSettingsRouteChildren {
+  AuthenticatedWorkspaceWorkspaceSlugSettingsGeneralRoute: typeof AuthenticatedWorkspaceWorkspaceSlugSettingsGeneralRoute
+  AuthenticatedWorkspaceWorkspaceSlugSettingsLabelsRoute: typeof AuthenticatedWorkspaceWorkspaceSlugSettingsLabelsRoute
+  AuthenticatedWorkspaceWorkspaceSlugSettingsMembersRoute: typeof AuthenticatedWorkspaceWorkspaceSlugSettingsMembersRoute
+  AuthenticatedWorkspaceWorkspaceSlugSettingsTeamsRoute: typeof AuthenticatedWorkspaceWorkspaceSlugSettingsTeamsRoute
+  AuthenticatedWorkspaceWorkspaceSlugSettingsIndexRoute: typeof AuthenticatedWorkspaceWorkspaceSlugSettingsIndexRoute
+}
+
+const AuthenticatedWorkspaceWorkspaceSlugSettingsRouteChildren: AuthenticatedWorkspaceWorkspaceSlugSettingsRouteChildren =
+  {
+    AuthenticatedWorkspaceWorkspaceSlugSettingsGeneralRoute:
+      AuthenticatedWorkspaceWorkspaceSlugSettingsGeneralRoute,
+    AuthenticatedWorkspaceWorkspaceSlugSettingsLabelsRoute:
+      AuthenticatedWorkspaceWorkspaceSlugSettingsLabelsRoute,
+    AuthenticatedWorkspaceWorkspaceSlugSettingsMembersRoute:
+      AuthenticatedWorkspaceWorkspaceSlugSettingsMembersRoute,
+    AuthenticatedWorkspaceWorkspaceSlugSettingsTeamsRoute:
+      AuthenticatedWorkspaceWorkspaceSlugSettingsTeamsRoute,
+    AuthenticatedWorkspaceWorkspaceSlugSettingsIndexRoute:
+      AuthenticatedWorkspaceWorkspaceSlugSettingsIndexRoute,
+  }
+
+const AuthenticatedWorkspaceWorkspaceSlugSettingsRouteWithChildren =
+  AuthenticatedWorkspaceWorkspaceSlugSettingsRoute._addFileChildren(
+    AuthenticatedWorkspaceWorkspaceSlugSettingsRouteChildren,
+  )
+
 interface AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierRouteChildren {
   AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierIssueIssueIdentifierRoute: typeof AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierIssueIssueIdentifierRoute
   AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierIssuesIssueIdentifierRoute: typeof AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierIssuesIssueIdentifierRoute
@@ -370,18 +495,18 @@ const AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierRouteWithChildren =
   )
 
 interface AuthenticatedWorkspaceWorkspaceSlugRouteChildren {
+  AuthenticatedWorkspaceWorkspaceSlugSettingsRoute: typeof AuthenticatedWorkspaceWorkspaceSlugSettingsRouteWithChildren
   AuthenticatedWorkspaceWorkspaceSlugIndexRoute: typeof AuthenticatedWorkspaceWorkspaceSlugIndexRoute
-  AuthenticatedWorkspaceWorkspaceSlugSettingsTeamsRoute: typeof AuthenticatedWorkspaceWorkspaceSlugSettingsTeamsRoute
   AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierRoute: typeof AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierRouteWithChildren
   AuthenticatedWorkspaceWorkspaceSlugMyIssuesIndexRoute: typeof AuthenticatedWorkspaceWorkspaceSlugMyIssuesIndexRoute
 }
 
 const AuthenticatedWorkspaceWorkspaceSlugRouteChildren: AuthenticatedWorkspaceWorkspaceSlugRouteChildren =
   {
+    AuthenticatedWorkspaceWorkspaceSlugSettingsRoute:
+      AuthenticatedWorkspaceWorkspaceSlugSettingsRouteWithChildren,
     AuthenticatedWorkspaceWorkspaceSlugIndexRoute:
       AuthenticatedWorkspaceWorkspaceSlugIndexRoute,
-    AuthenticatedWorkspaceWorkspaceSlugSettingsTeamsRoute:
-      AuthenticatedWorkspaceWorkspaceSlugSettingsTeamsRoute,
     AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierRoute:
       AuthenticatedWorkspaceWorkspaceSlugTeamTeamIdentifierRouteWithChildren,
     AuthenticatedWorkspaceWorkspaceSlugMyIssuesIndexRoute:

--- a/apps/web/src/routes/_authenticated/workspace/$workspaceSlug/settings.tsx
+++ b/apps/web/src/routes/_authenticated/workspace/$workspaceSlug/settings.tsx
@@ -1,0 +1,42 @@
+import { createFileRoute, Link, Outlet } from '@tanstack/react-router'
+
+export const Route = createFileRoute(
+  '/_authenticated/workspace/$workspaceSlug/settings',
+)({
+  component: SettingsLayout,
+})
+
+function SettingsLayout() {
+  const { workspaceSlug } = Route.useParams()
+
+  const tabs = [
+    { label: 'General', to: '/workspace/$workspaceSlug/settings/general' },
+    { label: 'Members', to: '/workspace/$workspaceSlug/settings/members' },
+    { label: 'Labels', to: '/workspace/$workspaceSlug/settings/labels' },
+    { label: 'Teams', to: '/workspace/$workspaceSlug/settings/teams' },
+  ] as const
+
+  return (
+    <div className="flex-1 overflow-y-auto p-8" data-testid="settings-layout">
+      <h1 className="text-xl font-bold text-white mb-6">Settings</h1>
+      <nav className="flex gap-1 border-b border-white/10 mb-6">
+        {tabs.map((tab) => (
+          <Link
+            key={tab.to}
+            to={tab.to}
+            params={{ workspaceSlug }}
+            data-testid={`settings-tab-${tab.label.toLowerCase()}`}
+            className="px-4 py-2 text-sm text-gray-400 hover:text-gray-200 border-b-2 border-transparent -mb-px"
+            activeProps={{
+              className:
+                'text-white border-b-2 border-indigo-500 -mb-px px-4 py-2 text-sm',
+            }}
+          >
+            {tab.label}
+          </Link>
+        ))}
+      </nav>
+      <Outlet />
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/workspace/$workspaceSlug/settings/general.tsx
+++ b/apps/web/src/routes/_authenticated/workspace/$workspaceSlug/settings/general.tsx
@@ -1,0 +1,85 @@
+import { useState, useEffect } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import { useWorkspaces, useUpdateWorkspace } from '@/hooks/use-workspaces'
+import { Button, Input } from '@/components/ui'
+
+export const Route = createFileRoute(
+  '/_authenticated/workspace/$workspaceSlug/settings/general',
+)({
+  component: GeneralSettingsPage,
+})
+
+function GeneralSettingsPage() {
+  const { workspaceSlug } = Route.useParams()
+  const { data: workspaces } = useWorkspaces()
+  const workspace = workspaces?.find((ws) => ws.slug === workspaceSlug)
+  const updateWorkspace = useUpdateWorkspace()
+
+  const [name, setName] = useState('')
+
+  useEffect(() => {
+    if (workspace) {
+      setName(workspace.name)
+    }
+  }, [workspace])
+
+  const handleSave = () => {
+    if (!workspace || !name.trim() || name.trim() === workspace.name) return
+    updateWorkspace.mutate({
+      workspaceId: workspace.id,
+      name: name.trim(),
+    })
+  }
+
+  const isDirty = workspace && name.trim() !== workspace.name && name.trim()
+
+  return (
+    <div className="max-w-lg" data-testid="general-settings-page">
+      <div className="space-y-6">
+        <div>
+          <label
+            htmlFor="workspace-name"
+            className="block text-sm font-medium text-gray-300 mb-1.5"
+          >
+            Workspace name
+          </label>
+          <Input
+            id="workspace-name"
+            data-testid="workspace-name-input"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-300 mb-1.5">
+            Workspace URL slug
+          </label>
+          <Input
+            data-testid="workspace-slug-input"
+            value={workspace?.slug ?? ''}
+            disabled
+            className="opacity-60"
+          />
+          <p className="text-xs text-gray-500 mt-1">
+            The URL slug cannot be changed.
+          </p>
+        </div>
+        {updateWorkspace.error && (
+          <p
+            className="text-sm text-red-400"
+            data-testid="general-settings-error"
+          >
+            {updateWorkspace.error.message}
+          </p>
+        )}
+        <Button
+          data-testid="save-workspace-name"
+          onClick={handleSave}
+          disabled={!isDirty || updateWorkspace.isPending}
+        >
+          {updateWorkspace.isPending ? 'Saving...' : 'Save changes'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/workspace/$workspaceSlug/settings/index.tsx
+++ b/apps/web/src/routes/_authenticated/workspace/$workspaceSlug/settings/index.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+export const Route = createFileRoute(
+  '/_authenticated/workspace/$workspaceSlug/settings/',
+)({
+  beforeLoad: ({ params }) => {
+    throw redirect({
+      to: '/workspace/$workspaceSlug/settings/general',
+      params: { workspaceSlug: params.workspaceSlug },
+    })
+  },
+})

--- a/apps/web/src/routes/_authenticated/workspace/$workspaceSlug/settings/labels.tsx
+++ b/apps/web/src/routes/_authenticated/workspace/$workspaceSlug/settings/labels.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute(
+  '/_authenticated/workspace/$workspaceSlug/settings/labels',
+)({
+  component: LabelsSettingsPage,
+})
+
+function LabelsSettingsPage() {
+  return (
+    <div className="max-w-2xl" data-testid="labels-settings-page">
+      <h2 className="text-lg font-semibold text-white mb-4">Labels</h2>
+      <p className="text-gray-400 text-sm">Label management coming soon.</p>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/workspace/$workspaceSlug/settings/members.tsx
+++ b/apps/web/src/routes/_authenticated/workspace/$workspaceSlug/settings/members.tsx
@@ -1,0 +1,189 @@
+import { useState } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import { useWorkspaces } from '@/hooks/use-workspaces'
+import {
+  useWorkspaceMembers,
+  useAddWorkspaceMember,
+  type WorkspaceMemberWithUser,
+} from '@/hooks/use-workspace-members'
+import {
+  Button,
+  Input,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+  Select,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+  SelectValue,
+} from '@/components/ui'
+
+export const Route = createFileRoute(
+  '/_authenticated/workspace/$workspaceSlug/settings/members',
+)({
+  component: MembersSettingsPage,
+})
+
+function MembersSettingsPage() {
+  const { workspaceSlug } = Route.useParams()
+  const { data: workspaces } = useWorkspaces()
+  const workspace = workspaces?.find((ws) => ws.slug === workspaceSlug)
+  const { data: members } = useWorkspaceMembers(workspace?.id ?? '')
+  const [addDialogOpen, setAddDialogOpen] = useState(false)
+
+  return (
+    <div className="max-w-2xl" data-testid="members-settings-page">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-white">Members</h2>
+        <Button
+          data-testid="add-member-button"
+          onClick={() => setAddDialogOpen(true)}
+        >
+          Add member
+        </Button>
+      </div>
+
+      {members && members.length === 0 && (
+        <p className="text-gray-400 text-sm" data-testid="no-members-message">
+          No members yet.
+        </p>
+      )}
+
+      <table className="w-full text-sm" data-testid="members-table">
+        <thead>
+          <tr className="border-b border-white/10 text-left text-gray-400">
+            <th className="pb-2 font-medium">Name</th>
+            <th className="pb-2 font-medium">Email</th>
+            <th className="pb-2 font-medium">Role</th>
+            <th className="pb-2 font-medium">Joined</th>
+          </tr>
+        </thead>
+        <tbody>
+          {members?.map((member) => (
+            <MemberRow key={member.id} member={member} />
+          ))}
+        </tbody>
+      </table>
+
+      {workspace && (
+        <AddMemberDialog
+          open={addDialogOpen}
+          onOpenChange={setAddDialogOpen}
+          workspaceId={workspace.id}
+        />
+      )}
+    </div>
+  )
+}
+
+function MemberRow({ member }: { member: WorkspaceMemberWithUser }) {
+  return (
+    <tr
+      className="border-b border-white/5"
+      data-testid={`member-row-${member.user.email}`}
+    >
+      <td className="py-3 text-gray-200">{member.user.name || 'Unnamed'}</td>
+      <td className="py-3 text-gray-400">{member.user.email}</td>
+      <td className="py-3">
+        <span className="rounded bg-white/10 px-2 py-0.5 text-xs text-gray-300 capitalize">
+          {member.role}
+        </span>
+      </td>
+      <td className="py-3 text-gray-500">
+        {new Date(member.createdAt).toLocaleDateString()}
+      </td>
+    </tr>
+  )
+}
+
+function AddMemberDialog({
+  open,
+  onOpenChange,
+  workspaceId,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  workspaceId: string
+}) {
+  const [userId, setUserId] = useState('')
+  const [role, setRole] = useState<'admin' | 'member'>('member')
+  const addMember = useAddWorkspaceMember()
+
+  const handleSubmit = () => {
+    if (!userId.trim()) return
+    addMember.mutate(
+      { workspaceId, userId: userId.trim(), role },
+      {
+        onSuccess: () => {
+          setUserId('')
+          setRole('member')
+          onOpenChange(false)
+        },
+      },
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogTitle>Add member</DialogTitle>
+        <DialogDescription>
+          Add a user to this workspace by their user ID.
+        </DialogDescription>
+        <div className="mt-4 space-y-4">
+          <div>
+            <label
+              htmlFor="user-id"
+              className="block text-sm font-medium text-gray-300 mb-1.5"
+            >
+              User ID
+            </label>
+            <Input
+              id="user-id"
+              data-testid="add-member-user-id"
+              value={userId}
+              onChange={(e) => setUserId(e.target.value)}
+              placeholder="Enter user ID"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              Role
+            </label>
+            <Select
+              value={role}
+              onValueChange={(v) => setRole(v as 'admin' | 'member')}
+            >
+              <SelectTrigger data-testid="add-member-role-select">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="member">Member</SelectItem>
+                <SelectItem value="admin">Admin</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          {addMember.error && (
+            <p className="text-sm text-red-400" data-testid="add-member-error">
+              {addMember.error.message}
+            </p>
+          )}
+          <div className="flex justify-end gap-2">
+            <Button variant="secondary" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button
+              data-testid="add-member-submit"
+              onClick={handleSubmit}
+              disabled={!userId.trim() || addMember.isPending}
+            >
+              {addMember.isPending ? 'Adding...' : 'Add member'}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/e2e/tests/teams/team-management.spec.ts
+++ b/e2e/tests/teams/team-management.spec.ts
@@ -64,13 +64,14 @@ test.describe('Team Management', () => {
     await expect(dialog.getByTestId('team-identifier-input')).toHaveValue('ENG')
   })
 
-  test('should navigate to teams settings page', async ({ page }) => {
+  test('should navigate to settings page', async ({ page }) => {
     await page.goto(`/workspace/${workspaceSlug}/my-issues`)
 
-    await page.getByTestId('sidebar-teams-settings').click()
+    await page.getByTestId('sidebar-settings').click()
 
-    await page.waitForURL(`/workspace/${workspaceSlug}/settings/teams`)
-    await expect(page.getByTestId('teams-settings-page')).toBeVisible()
+    await page.waitForURL(`/workspace/${workspaceSlug}/settings/general`)
+    await expect(page.getByTestId('settings-layout')).toBeVisible()
+    await expect(page.getByTestId('general-settings-page')).toBeVisible()
   })
 
   test('should list teams on settings page', async ({ page, api }) => {

--- a/e2e/tests/workspace/workspace-settings.spec.ts
+++ b/e2e/tests/workspace/workspace-settings.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from '../../fixtures/base.fixture.js'
+
+test.describe('Workspace Settings', () => {
+  let workspaceSlug: string
+
+  test.beforeEach(async ({ api }) => {
+    const ws = await api.createWorkspace('Settings Test Workspace')
+    workspaceSlug = ws.slug ?? 'settings-test-workspace'
+  })
+
+  test.describe('Settings Layout', () => {
+    test('should show settings layout with tabs', async ({ page }) => {
+      await page.goto(`/workspace/${workspaceSlug}/settings/general`)
+
+      await expect(page.getByTestId('settings-layout')).toBeVisible()
+      await expect(page.getByTestId('settings-tab-general')).toBeVisible()
+      await expect(page.getByTestId('settings-tab-members')).toBeVisible()
+      await expect(page.getByTestId('settings-tab-labels')).toBeVisible()
+      await expect(page.getByTestId('settings-tab-teams')).toBeVisible()
+    })
+
+    test('should navigate between settings tabs', async ({ page }) => {
+      await page.goto(`/workspace/${workspaceSlug}/settings/general`)
+      await expect(page.getByTestId('general-settings-page')).toBeVisible()
+
+      await page.getByTestId('settings-tab-members').click()
+      await page.waitForURL(`/workspace/${workspaceSlug}/settings/members`)
+      await expect(page.getByTestId('members-settings-page')).toBeVisible()
+
+      await page.getByTestId('settings-tab-teams').click()
+      await page.waitForURL(`/workspace/${workspaceSlug}/settings/teams`)
+      await expect(page.getByTestId('teams-settings-page')).toBeVisible()
+    })
+
+    test('should redirect /settings to /settings/general', async ({ page }) => {
+      await page.goto(`/workspace/${workspaceSlug}/settings`)
+      await page.waitForURL(`/workspace/${workspaceSlug}/settings/general`)
+      await expect(page.getByTestId('general-settings-page')).toBeVisible()
+    })
+  })
+
+  test.describe('General Tab', () => {
+    test('should display workspace name and slug', async ({ page }) => {
+      await page.goto(`/workspace/${workspaceSlug}/settings/general`)
+
+      const nameInput = page.getByTestId('workspace-name-input')
+      await expect(nameInput).toBeVisible()
+      await expect(nameInput).toHaveValue('Settings Test Workspace')
+
+      const slugInput = page.getByTestId('workspace-slug-input')
+      await expect(slugInput).toBeVisible()
+      await expect(slugInput).toBeDisabled()
+    })
+
+    test('should update workspace name', async ({ page }) => {
+      await page.goto(`/workspace/${workspaceSlug}/settings/general`)
+
+      const nameInput = page.getByTestId('workspace-name-input')
+      await nameInput.clear()
+      await nameInput.fill('Updated Workspace Name')
+
+      const saveButton = page.getByTestId('save-workspace-name')
+      await expect(saveButton).toBeEnabled()
+      await saveButton.click()
+
+      // Verify the name was updated (save button should be disabled again)
+      await expect(saveButton).toBeDisabled()
+    })
+
+    test('should disable save button when name unchanged', async ({ page }) => {
+      await page.goto(`/workspace/${workspaceSlug}/settings/general`)
+
+      const saveButton = page.getByTestId('save-workspace-name')
+      await expect(saveButton).toBeDisabled()
+    })
+  })
+
+  test.describe('Members Tab', () => {
+    test('should display members table with current user', async ({ page }) => {
+      await page.goto(`/workspace/${workspaceSlug}/settings/members`)
+
+      await expect(page.getByTestId('members-settings-page')).toBeVisible()
+      await expect(page.getByTestId('members-table')).toBeVisible()
+
+      // Current user should be listed as owner
+      const memberRows = page.locator('[data-testid^="member-row-"]')
+      await expect(memberRows).toHaveCount(1)
+    })
+
+    test('should show add member dialog', async ({ page }) => {
+      await page.goto(`/workspace/${workspaceSlug}/settings/members`)
+
+      await page.getByTestId('add-member-button').click()
+
+      const dialog = page.getByRole('dialog')
+      await expect(dialog).toBeVisible()
+      await expect(dialog.getByTestId('add-member-user-id')).toBeVisible()
+      await expect(dialog.getByTestId('add-member-role-select')).toBeVisible()
+      await expect(dialog.getByTestId('add-member-submit')).toBeVisible()
+    })
+  })
+
+  test.describe('Sidebar Navigation', () => {
+    test('should navigate to settings from sidebar', async ({ page }) => {
+      await page.goto(`/workspace/${workspaceSlug}/my-issues`)
+
+      await page.getByTestId('sidebar-settings').click()
+      await page.waitForURL(`/workspace/${workspaceSlug}/settings/general`)
+      await expect(page.getByTestId('settings-layout')).toBeVisible()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- 설정 레이아웃 추가 (General, Members, Labels, Teams 탭 네비게이션)
- General 탭: 워크스페이스 이름 수정 (`PATCH /workspaces/:id`), slug 읽기 전용 표시
- Members 탭: 멤버 목록 테이블 (이름, 이메일, 역할, 가입일) + 멤버 추가 다이얼로그
- `useWorkspaceMembers`, `useAddWorkspaceMember`, `useUpdateWorkspace` 훅 추가
- 사이드바 "Teams settings" → "Settings" 링크 변경
- Labels 탭 플레이스홀더 추가
- `data-testid` 속성 추가 + E2E 테스트 작성

Closes #83

## Test plan

- [x] `pnpm build` 성공
- [x] `pnpm lint` 통과
- [x] `/workspace/$slug/settings` → `/workspace/$slug/settings/general` 리다이렉트 확인
- [x] General 탭에서 워크스페이스 이름 수정 동작 확인
- [x] Members 탭에서 멤버 목록 표시 확인
- [x] 멤버 추가 다이얼로그 동작 확인
- [x] 사이드바 Settings 링크 클릭 시 설정 페이지 이동 확인
- [x] 탭 간 네비게이션 동작 확인
- [x] E2E 테스트 통과 (`pnpm --filter e2e test`)

### Verification details (review-agent-97)
- Build: ✅ FULL TURBO (cached, all 3 packages)
- Lint: ✅ clean
- E2E workspace-settings: ✅ 11/11 passed (12.1s)
- E2E team-management: ✅ 10/10 passed (9.5s)
- Runtime `PATCH /api/workspaces/:id`: ✅ name updated, updatedAt changed
- Runtime `GET /api/workspaces/:id/members`: ✅ returns member with joined user info (name, email, image)